### PR TITLE
Create AsyncQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/cocoapods/l/swift-async-queue.svg)](https://cocoapods.org/pods/swift-async-queue)
 [![Platform](https://img.shields.io/cocoapods/p/swift-async-queue.svg)](https://cocoapods.org/pods/swift-async-queue)
 
-A queue that enables ordered sending of events from synchronous to asynchronous code.
+A queue that enables sending FIFO-ordered tasks from synchronous to asynchronous contexts.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
 # swift-async-queue
-A queue that enables ordered sending of events from synchronous to asynchronous code
+[![Swift Package Manager compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://github.com/apple/swift-package-manager)
+[![codecov](https://codecov.io/gh/dfed/swift-async-queue/branch/main/graph/badge.svg?token=nZBHcZZ63F)](https://codecov.io/gh/dfed/swift-async-queue)
+[![Version](https://img.shields.io/cocoapods/v/swift-async-queue.svg)](https://cocoapods.org/pods/swift-async-queue)
+[![License](https://img.shields.io/cocoapods/l/swift-async-queue.svg)](https://cocoapods.org/pods/swift-async-queue)
+[![Platform](https://img.shields.io/cocoapods/p/swift-async-queue.svg)](https://cocoapods.org/pods/swift-async-queue)
+
+A queue that enables ordered sending of events from synchronous to asynchronous code.
+
+## Usage
+
+### Basic Initialization
+
+```swift
+let asyncQueue = AsyncQueue()
+```
+
+### Sending events from a synchronous context
+
+```swift
+asyncQueue.async { /* awaitable context that executes after all other enqueued work is completed */ }
+```
+
+### Awaiting work from an asynchronous context
+
+```swift
+await asyncQueue.await { /* throw-able, return-able, awaitable context that executes after all other enqueued work is completed */ }
+```
 
 ## Requirements
 

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -174,6 +174,9 @@ for rawPlatform in rawPlatforms {
     if platform.shouldTest {
         xcodeBuildArguments.append("test")
     }
+    xcodeBuildArguments.append("-test-iterations")
+    xcodeBuildArguments.append("100")
+    xcodeBuildArguments.append("-run-tests-until-failure")
 
     try execute(commandPath: "/usr/bin/xcodebuild", arguments: xcodeBuildArguments)
     isFirstRun = false

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -159,7 +159,8 @@ for rawPlatform in rawPlatforms {
         "-scheme", "swift-async-queue",
         "-sdk", platform.sdk,
         "-derivedDataPath", platform.derivedDataPath,
-        "-PBXBuildsContinueAfterErrors=0"
+        "-PBXBuildsContinueAfterErrors=0",
+        "OTHER_SWIFT_FLAGS=-warnings-as-errors",
     ]
 
     if !platform.destination.isEmpty {

--- a/Sources/AsyncQueue/AsyncQueue.swift
+++ b/Sources/AsyncQueue/AsyncQueue.swift
@@ -20,4 +20,70 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-final class AsyncQueue {}
+/// A queue that enables ordered sending of events from synchronous to asynchronous code
+public final class AsyncQueue: Sendable {
+
+    // MARK: Initialization
+
+    /// Instantiates an asynchronous queue.
+    /// - Parameter priority: The priority of the tasks added to the asynchronous queue.
+    public init(priority: TaskPriority = .medium) {
+        var capturedTaskStreamContinuation: AsyncStream<@Sendable () async -> Void>.Continuation? = nil
+        let taskStream = AsyncStream<@Sendable () async -> Void> { continuation in
+            capturedTaskStreamContinuation = continuation
+        }
+        taskStreamContinuation = capturedTaskStreamContinuation
+
+        streamTask = Task.detached(priority: priority) {
+            for await task in taskStream {
+                await task()
+            }
+        }
+    }
+
+    deinit {
+        taskStreamContinuation.finish()
+    }
+
+    // MARK: Public
+
+    /// Schedules an asynchronous task for execution and immediately returns.
+    /// The schedueled task will not execute until all prior tasks have completed.
+    /// - Parameter task: The task to enqueue.
+    public func async(_ task: @escaping @Sendable () async -> Void) {
+        taskStreamContinuation.yield(task)
+    }
+
+    /// Schedules an asynchronous throwing task and returns after the task is complete.
+    /// The schedueled task will not execute until all prior tasks have completed.
+    /// - Parameter task: The task to enqueue.
+    /// - Returns: The value returned from the enqueued task.
+    public func await<T>(_ task: @escaping @Sendable () async -> T) async -> T {
+        await withUnsafeContinuation { continuation in
+            taskStreamContinuation.yield {
+                continuation.resume(returning: await task())
+            }
+        }
+    }
+
+    /// Schedules an asynchronous task and returns after the task is complete.
+    /// The schedueled task will not execute until all prior tasks have completed.
+    /// - Parameter task: The task to enqueue.
+    /// - Returns: The value returned from the enqueued task.
+    public func await<T>(_ task: @escaping @Sendable () async throws -> T) async throws -> T {
+        try await withUnsafeThrowingContinuation { continuation in
+            taskStreamContinuation.yield {
+                do {
+                    continuation.resume(returning: try await task())
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private let streamTask: Task<Void, Never>
+    private let taskStreamContinuation: AsyncStream<@Sendable () async -> Void>.Continuation!
+}

--- a/Sources/AsyncQueue/AsyncQueue.swift
+++ b/Sources/AsyncQueue/AsyncQueue.swift
@@ -32,7 +32,7 @@ public final class AsyncQueue: Sendable {
         let taskStream = AsyncStream<@Sendable () async -> Void> { continuation in
             capturedTaskStreamContinuation = continuation
         }
-        guard let capturedTaskStreamContinuation = capturedTaskStreamContinuation else {
+        guard let capturedTaskStreamContinuation else {
             fatalError("Continuation not captured during stream creation!")
         }
         taskStreamContinuation = capturedTaskStreamContinuation

--- a/Sources/AsyncQueue/AsyncQueue.swift
+++ b/Sources/AsyncQueue/AsyncQueue.swift
@@ -32,10 +32,9 @@ public final class AsyncQueue: Sendable {
         let taskStream = AsyncStream<@Sendable () async -> Void> { continuation in
             capturedTaskStreamContinuation = continuation
         }
-        guard let capturedTaskStreamContinuation else {
-            fatalError("Continuation not captured during stream creation!")
-        }
-        taskStreamContinuation = capturedTaskStreamContinuation
+        // Continuation will be captured during stream creation, so it is safe to force unwrap here.
+        // If this force-unwrap fails, something is fundamentally broken in the Swift runtime.
+        taskStreamContinuation = capturedTaskStreamContinuation!
 
         streamTask = Task.detached(priority: priority) {
             for await task in taskStream {

--- a/Sources/AsyncQueue/AsyncQueue.swift
+++ b/Sources/AsyncQueue/AsyncQueue.swift
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/// A queue that enables ordered sending of events from synchronous to asynchronous code
+/// A queue that enables sending FIFO-ordered tasks from synchronous to asynchronous contexts
 public final class AsyncQueue: Sendable {
 
     // MARK: Initialization

--- a/Sources/AsyncQueue/AsyncQueue.swift
+++ b/Sources/AsyncQueue/AsyncQueue.swift
@@ -26,7 +26,7 @@ public final class AsyncQueue: Sendable {
     // MARK: Initialization
 
     /// Instantiates an asynchronous queue.
-    /// - Parameter priority: The priority of the tasks added to the asynchronous queue.
+    /// - Parameter priority: The baseline priority of the tasks added to the asynchronous queue.
     public init(priority: TaskPriority = .medium) {
         var capturedTaskStreamContinuation: AsyncStream<@Sendable () async -> Void>.Continuation? = nil
         let taskStream = AsyncStream<@Sendable () async -> Void> { continuation in

--- a/Sources/AsyncQueue/AsyncQueue.swift
+++ b/Sources/AsyncQueue/AsyncQueue.swift
@@ -27,7 +27,7 @@ public final class AsyncQueue: Sendable {
 
     /// Instantiates an asynchronous queue.
     /// - Parameter priority: The baseline priority of the tasks added to the asynchronous queue.
-    public init(priority: TaskPriority = .medium) {
+    public init(priority: TaskPriority? = nil) {
         var capturedTaskStreamContinuation: AsyncStream<@Sendable () async -> Void>.Continuation? = nil
         let taskStream = AsyncStream<@Sendable () async -> Void> { continuation in
             capturedTaskStreamContinuation = continuation

--- a/Sources/AsyncQueue/AsyncQueue.swift
+++ b/Sources/AsyncQueue/AsyncQueue.swift
@@ -32,6 +32,9 @@ public final class AsyncQueue: Sendable {
         let taskStream = AsyncStream<@Sendable () async -> Void> { continuation in
             capturedTaskStreamContinuation = continuation
         }
+        guard let capturedTaskStreamContinuation = capturedTaskStreamContinuation else {
+            fatalError("Continuation not captured during stream creation!")
+        }
         taskStreamContinuation = capturedTaskStreamContinuation
 
         streamTask = Task.detached(priority: priority) {
@@ -85,5 +88,5 @@ public final class AsyncQueue: Sendable {
     // MARK: Private
 
     private let streamTask: Task<Void, Never>
-    private let taskStreamContinuation: AsyncStream<@Sendable () async -> Void>.Continuation!
+    private let taskStreamContinuation: AsyncStream<@Sendable () async -> Void>.Continuation
 }

--- a/Tests/AsyncQueueTests/AsyncQueueTests.swift
+++ b/Tests/AsyncQueueTests/AsyncQueueTests.swift
@@ -26,8 +26,149 @@ import XCTest
 
 final class AsyncQueueTests: XCTestCase {
 
-    func test_example() {
-        _ = AsyncQueue()
+    // MARK: XCTestCase
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        systemUnderTest = AsyncQueue()
+    }
+
+    override func tearDown() async throws {
+        try await super.tearDown()
+
+        await systemUnderTest.await { /* Drain the queue */ }
+    }
+
+    // MARK: Behavior Tests
+
+    func test_async_sendsEventsInOrder() {
+        let counter = Counter()
+        for iteration in 1...1_000 {
+            systemUnderTest.async {
+                await counter.incrementAndExpectCount(equals: iteration)
+            }
+        }
+    }
+
+    func test_async_executesAsyncBlocksSeriallyAndAtomically() {
+        let unsafeCounter = UnsafeCounter()
+        for iteration in 1...1_000 {
+            systemUnderTest.async {
+                unsafeCounter.incrementAndExpectCount(equals: iteration)
+            }
+        }
+    }
+
+    func test_async_isNotReentrant() async {
+        let counter = Counter()
+        await systemUnderTest.await { [systemUnderTest] in
+            systemUnderTest.async {
+                await counter.incrementAndExpectCount(equals: 2)
+            }
+            await counter.incrementAndExpectCount(equals: 1)
+            systemUnderTest.async {
+                await counter.incrementAndExpectCount(equals: 3)
+            }
+        }
+    }
+
+    func test_async_retainsReceiverUntilFlushed() async {
+        var systemUnderTest: AsyncQueue? = AsyncQueue()
+        let counter = Counter()
+        let expectation = self.expectation(description: #function)
+        await withThrowingTaskGroup(of: Void.self) { taskGroup in
+            let foreverSleep = Task {
+                try await Task.sleep(nanoseconds: UInt64.max)
+            }
+            taskGroup.addTask {
+                try await foreverSleep.value
+            }
+            systemUnderTest?.async {
+                // Make the queue wait.
+                try? await foreverSleep.value
+                await counter.incrementAndExpectCount(equals: 1)
+            }
+            systemUnderTest?.async {
+                // This async task should not execute until the sleep is cancelled.
+                await counter.incrementAndExpectCount(equals: 2)
+                expectation.fulfill()
+            }
+            // Nil out our reference to the queue to show that the enqueued tasks will still complete
+            systemUnderTest = nil
+            // Cancel the sleep timer to unlock the remaining enqueued tasks.
+            foreverSleep.cancel()
+
+            await waitForExpectations(timeout: 1.0)
+        }
+    }
+
+    func test_await_sendsEventsInOrder() async {
+        let counter = Counter()
+        for iteration in 1...1_000 {
+            systemUnderTest.async {
+                await counter.incrementAndExpectCount(equals: iteration)
+            }
+
+            guard iteration % 25 == 0 else {
+                // Keep sending async events to the queue.
+                continue
+            }
+
+            await systemUnderTest.await {
+                let count = await counter.count
+                XCTAssertEqual(count, iteration)
+            }
+        }
+    }
+
+    func test_await_canReturn() async {
+        let expectedValue = UUID()
+        let returnedValue = await systemUnderTest.await { expectedValue }
+        XCTAssertEqual(expectedValue, returnedValue)
+    }
+
+    func test_await_canThrow() async {
+        struct TestError: Error, Equatable {
+            private let identifier = UUID()
+        }
+        let expectedError = TestError()
+        do {
+            try await systemUnderTest.await { throw expectedError }
+        } catch {
+            XCTAssertEqual(error as? TestError, expectedError)
+        }
+    }
+
+    // MARK: Private
+
+    private var systemUnderTest = AsyncQueue()
+
+    // MARK: - Counter
+
+    private actor Counter {
+        func incrementAndExpectCount(equals expectedCount: Int) {
+            increment()
+            XCTAssertEqual(expectedCount, count)
+        }
+
+        func increment() {
+            count += 1
+        }
+
+        var count = 0
+    }
+
+    // MARK: - UnsafeCounter
+
+    /// A counter that is explicitly not safe to utilize concurrently.
+    private final class UnsafeCounter: @unchecked Sendable {
+        func incrementAndExpectCount(equals expectedCount: Int) {
+            count += 1
+            XCTAssertEqual(expectedCount, count)
+        }
+
+        var count = 0
     }
 
 }

--- a/Tests/AsyncQueueTests/AsyncQueueTests.swift
+++ b/Tests/AsyncQueueTests/AsyncQueueTests.swift
@@ -34,24 +34,19 @@ final class AsyncQueueTests: XCTestCase {
         systemUnderTest = AsyncQueue()
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
-
-        await systemUnderTest.await { /* Drain the queue */ }
-    }
-
     // MARK: Behavior Tests
 
-    func test_async_sendsEventsInOrder() {
+    func test_async_sendsEventsInOrder() async {
         let counter = Counter()
         for iteration in 1...1_000 {
             systemUnderTest.async {
                 await counter.incrementAndExpectCount(equals: iteration)
             }
         }
+        await systemUnderTest.await { /* Drain the queue */ }
     }
 
-    func test_async_executesAsyncBlocksAtomically() {
+    func test_async_executesAsyncBlocksAtomically() async {
         let semaphore = Semaphore()
         for _ in 1...1_000 {
             systemUnderTest.async {
@@ -67,6 +62,7 @@ final class AsyncQueueTests: XCTestCase {
                 await semaphore.wait()
             }
         }
+        await systemUnderTest.await { /* Drain the queue */ }
     }
 
     func test_async_isNotReentrant() async {
@@ -80,6 +76,7 @@ final class AsyncQueueTests: XCTestCase {
                 await counter.incrementAndExpectCount(equals: 3)
             }
         }
+        await systemUnderTest.await { /* Drain the queue */ }
     }
 
     func test_async_retainsReceiverUntilFlushed() async {
@@ -150,6 +147,7 @@ final class AsyncQueueTests: XCTestCase {
                 XCTAssertEqual(count, iteration)
             }
         }
+        await systemUnderTest.await { /* Drain the queue */ }
     }
 
     func test_await_canReturn() async {

--- a/Tests/AsyncQueueTests/AsyncQueueTests.swift
+++ b/Tests/AsyncQueueTests/AsyncQueueTests.swift
@@ -93,7 +93,7 @@ final class AsyncQueueTests: XCTestCase {
             await counter.incrementAndExpectCount(equals: 1)
         }
         systemUnderTest?.async {
-            // This async task should not execute until the sleep is cancelled.
+            // This async task should not execute until the semaphore is released.
             await counter.incrementAndExpectCount(equals: 2)
             expectation.fulfill()
         }


### PR DESCRIPTION
This PR introduces the `AsyncQueue` class, which makes it possible to send ordered work to an asynchronous context from a synchronous or non-isolated context.

Any and all API feedback is welcome! Note that the name of the queue changes in #3, which builds upon this work.