### PR TITLE
Replace actions/setup-ruby@v1 with ruby/setup-ruby@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   #   name: Pod Lint
   #   runs-on: macOS-12
   #   steps:
-  #     - uses: actions/setup-ruby@v1
+  #     - uses: ruby/setup-ruby@v1
   #       with:
   #         ruby-version: '2.7.6'
   #     - name: Checkout Repo
@@ -35,7 +35,7 @@ jobs:
         ]
       fail-fast: false
     steps:
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.6'
       - name: Checkout Repo
@@ -55,7 +55,7 @@ jobs:
     name: Swift Build Xcode 14
     runs-on: macOS-12
     steps:
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.6'
       - name: Checkout Repo


### PR DESCRIPTION
As title. The former is deprecated and is [causing CI failures](https://github.com/dfed/swift-async-queue/actions/runs/3610664425/jobs/6084591971#step:2:6)