### PR TITLE
Add tests for Semaphore type

### DIFF
--- a/Tests/AsyncQueueTests/SemaphoreTests.swift
+++ b/Tests/AsyncQueueTests/SemaphoreTests.swift
@@ -33,10 +33,10 @@ final class SemaphoreTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        try await super.tearDown()
-
         let isWaiting = await systemUnderTest.isWaiting
         XCTAssertFalse(isWaiting)
+
+        try await super.tearDown()
     }
 
     // MARK: Behavior Tests

--- a/Tests/AsyncQueueTests/SemaphoreTests.swift
+++ b/Tests/AsyncQueueTests/SemaphoreTests.swift
@@ -35,9 +35,8 @@ final class SemaphoreTests: XCTestCase {
     override func tearDown() async throws {
         try await super.tearDown()
 
-        while await systemUnderTest.isWaiting {
-            await systemUnderTest.signal()
-        }
+        let isWaiting = await systemUnderTest.isWaiting
+        XCTAssertFalse(isWaiting)
     }
 
     // MARK: Behavior Tests

--- a/Tests/AsyncQueueTests/SemaphoreTests.swift
+++ b/Tests/AsyncQueueTests/SemaphoreTests.swift
@@ -1,0 +1,137 @@
+// MIT License
+//
+// Copyright (c) 2022 Dan Federman
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+
+final class SemaphoreTests: XCTestCase {
+
+    // MARK: XCTestCase
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        systemUnderTest = Semaphore()
+    }
+
+    override func tearDown() async throws {
+        try await super.tearDown()
+
+        while await systemUnderTest.isWaiting {
+            await systemUnderTest.signal()
+        }
+    }
+
+    // MARK: Behavior Tests
+
+    func test_wait_suspendsUntilEqualNumberOfSignalCalls() async {
+        /*
+         This test is tricky to pull off!
+         Our requirements:
+         1. We need to call `wait()` before `signal()`
+         2. We need to ensure that the `wait()` call suspends _before_ we call `signal()`
+         3. We can't `await` the `wait()` call before calling `signal()` since that would effectively deadlock the test.
+
+         In order to ensure that we are executing the `wait()` calls before we call `signal()` _without awaiting a `wait()` call_,
+         we utilize an Actor (which has inherently ordered execution) to enqueue ordered `Task`s. We make calls to this actor
+         `await` the beginning of the `Task` to ensure that each `Task` has begun before resuming the test's execution.
+         */
+
+        actor CountingExecutor {
+            /// Enqueues an asynchronous task. This method suspends the caller until the asynchronous task has begun, ensuring ordered execution of enqueued tasks.
+            /// - Parameter task: A unit of work that returns work to execute after the task completes and the count is incremented.
+            func enqueueAndCount(_ task: @escaping @Sendable () async -> (() async -> Void)?) async {
+                // Await the start of the soon-to-be-enqueued `Task` with a continuation.
+                await withCheckedContinuation { continuation in
+                    // Re-enter the actor context but don't wait for the result.
+                    Task {
+                        // Now that we're back in the actor context, resume the calling code.
+                        continuation.resume()
+                        let executeAfterIncrement = await task()
+                        countedTasksCompleted += 1
+                        await executeAfterIncrement?()
+                    }
+                }
+            }
+
+            func execute(_ task: @Sendable () async throws -> Void) async rethrows {
+                try await task()
+            }
+
+            var countedTasksCompleted = 0
+        }
+
+        let executor = CountingExecutor()
+        let iterationCount = 1_000
+
+        for _ in 1...iterationCount {
+            await executor.enqueueAndCount {
+                let didSuspend = await self.systemUnderTest.wait()
+                XCTAssertTrue(didSuspend)
+
+                return {
+                    // Signal that the suspended wait call above has resumed.
+                    // This signal allows us to `wait()` for all of these enqueued `wait()` tasks to have completed later in this test.
+                    await self.systemUnderTest.signal()
+                }
+            }
+        }
+
+        // Loop one fewer than iterationCount.
+        for _ in 1..<iterationCount {
+            await executor.execute {
+                await self.systemUnderTest.signal()
+            }
+        }
+
+        await executor.execute {
+            // Give each suspended `wait` task an opportunity to resume (if they were to resume, which they won't) before we check the count.
+            for _ in 1...iterationCount {
+                await Task.yield()
+            }
+
+            // The count will still be zero each time because we have executed one more `wait` than `signal` calls.
+            let completedCountedTasks = await executor.countedTasksCompleted
+            XCTAssertEqual(completedCountedTasks, 0)
+
+            // Signal one last time, enabling all of the original `wait` calls to resume.
+            await self.systemUnderTest.signal()
+
+            for _ in 1...iterationCount {
+                // Wait for all enqueued `wait`s to have completed and signaled their completion.
+                await self.systemUnderTest.wait()
+            }
+
+            let tasksCompleted = await executor.countedTasksCompleted
+            XCTAssertEqual(iterationCount, tasksCompleted)
+        }
+    }
+
+    func test_wait_doesNotSuspendIfSignalCalledFirst() async {
+        await systemUnderTest.signal()
+        let didSuspend = await systemUnderTest.wait()
+        XCTAssertFalse(didSuspend)
+    }
+
+    // MARK: Private
+
+    private var systemUnderTest = Semaphore()
+}

--- a/Tests/AsyncQueueTests/SemaphoreTests.swift
+++ b/Tests/AsyncQueueTests/SemaphoreTests.swift
@@ -47,7 +47,7 @@ final class SemaphoreTests: XCTestCase {
          Our requirements:
          1. We need to call `wait()` before `signal()`
          2. We need to ensure that the `wait()` call suspends _before_ we call `signal()`
-         3. We can't `await` the `wait()` call before calling `signal()` since that would effectively deadlock the test.
+         3. We can't `await` the `wait()` call on the test's queue before calling `signal()` since that would deadlock the test.
          4. We must utilize a single actor's isolated context to avoid accidental interleaving when suspending to communicate across actor contexts.
 
          In order to ensure that we are executing the `wait()` calls before we call `signal()` _without awaiting a `wait()` call_,

--- a/Tests/AsyncQueueTests/SemaphoreTests.swift
+++ b/Tests/AsyncQueueTests/SemaphoreTests.swift
@@ -51,8 +51,7 @@ final class SemaphoreTests: XCTestCase {
          4. We must utilize a single actor's isolated context to avoid accidental interleaving when suspending to communicate across actor contexts.
 
          In order to ensure that we are executing the `wait()` calls before we call `signal()` _without awaiting a `wait()` call_,
-         we utilize an Actor (which has inherently ordered execution) to enqueue ordered `Task`s. We make calls to this actor
-         `await` the beginning of the `Task` to ensure that each `Task` has begun before resuming the test's execution.
+         we utilize the Sempahore's ordered execution context to enqueue ordered `Task`s similar to how an ActorQueue works.
          */
 
         let iterationCount = 1_000

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,5 +10,5 @@ coverage:
   status:
     project:
       default:
-        threshold: 0.25%
+        target: 100%
     patch: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,7 +12,3 @@ coverage:
       default:
         threshold: 0.25%
     patch: off
-
-ignore:
-  # This package is not shipped.
-  - "Tests"


### PR DESCRIPTION
This PR adds tests for the `Semaphore` type used in unit tests.

These tests aren't strictly necessary since the `Semaphore` type only lives under the `Tests` directory. But I found writing these tests instructive, so I figured they'd be worthwhile to land in the repo as prior art.