### PR TITLE
Enable executing FIFO tasks on a desired actor's execution context

### DIFF
--- a/Sources/AsyncQueue/FIFOQueue.swift
+++ b/Sources/AsyncQueue/FIFOQueue.swift
@@ -59,7 +59,7 @@ public final class FIFOQueue: Sendable {
     }
 
     /// Schedules an asynchronous task for execution and immediately returns.
-    /// The scheduled task will not execute until all prior tasks have completed or suspended.
+    /// The scheduled task will not execute until all prior tasks have completed.
     /// - Parameters:
     ///   - isolatedActor: The actor within which the task is isolated.
     ///   - task: The task to enqueue.
@@ -80,7 +80,7 @@ public final class FIFOQueue: Sendable {
     }
 
     /// Schedules an asynchronous task and returns after the task is complete.
-    /// The scheduled task will not execute until all prior tasks have completed or suspended.
+    /// The scheduled task will not execute until all prior tasks have completed.
     /// - Parameters:
     ///   - isolatedActor: The actor within which the task is isolated.
     ///   - task: The task to enqueue.
@@ -110,7 +110,7 @@ public final class FIFOQueue: Sendable {
     }
 
     /// Schedules an asynchronous throwing task and returns after the task is complete.
-    /// The scheduled task will not execute until all prior tasks have completed or suspended.
+    /// The scheduled task will not execute until all prior tasks have completed.
     /// - Parameters:
     ///   - isolatedActor: The actor within which the task is isolated.
     ///   - task: The task to enqueue.

--- a/Sources/AsyncQueue/FIFOQueue.swift
+++ b/Sources/AsyncQueue/FIFOQueue.swift
@@ -58,6 +58,15 @@ public final class FIFOQueue: Sendable {
         taskStreamContinuation.yield(task)
     }
 
+    /// Schedules an asynchronous task for execution and immediately returns.
+    /// The scheduled task will not execute until all prior tasks have completed or suspended.
+    /// - Parameters:
+    ///   - isolatedActor: The actor within which the task is isolated.
+    ///   - task: The task to enqueue.
+    public func async<ActorType: Actor>(on isolatedActor: ActorType, _ task: @escaping @Sendable (isolated ActorType) async -> Void) {
+        taskStreamContinuation.yield { await task(isolatedActor) }
+    }
+
     /// Schedules an asynchronous task and returns after the task is complete.
     /// The scheduled task will not execute until all prior tasks have completed.
     /// - Parameter task: The task to enqueue.
@@ -66,6 +75,20 @@ public final class FIFOQueue: Sendable {
         await withUnsafeContinuation { continuation in
             taskStreamContinuation.yield {
                 continuation.resume(returning: await task())
+            }
+        }
+    }
+
+    /// Schedules an asynchronous task and returns after the task is complete.
+    /// The scheduled task will not execute until all prior tasks have completed or suspended.
+    /// - Parameters:
+    ///   - isolatedActor: The actor within which the task is isolated.
+    ///   - task: The task to enqueue.
+    /// - Returns: The value returned from the enqueued task.
+    public func await<ActorType: Actor, T>(on isolatedActor: isolated ActorType, _ task: @escaping @Sendable (isolated ActorType) async -> T) async -> T {
+        await withUnsafeContinuation { continuation in
+            taskStreamContinuation.yield {
+                continuation.resume(returning: await task(isolatedActor))
             }
         }
     }
@@ -79,6 +102,24 @@ public final class FIFOQueue: Sendable {
             taskStreamContinuation.yield {
                 do {
                     continuation.resume(returning: try await task())
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Schedules an asynchronous throwing task and returns after the task is complete.
+    /// The scheduled task will not execute until all prior tasks have completed or suspended.
+    /// - Parameters:
+    ///   - isolatedActor: The actor within which the task is isolated.
+    ///   - task: The task to enqueue.
+    /// - Returns: The value returned from the enqueued task.
+    public func await<ActorType: Actor, T>(on isolatedActor: isolated ActorType, _ task: @escaping @Sendable (isolated ActorType) async throws -> T) async throws -> T {
+        try await withUnsafeThrowingContinuation { continuation in
+            taskStreamContinuation.yield {
+                do {
+                    continuation.resume(returning: try await task(isolatedActor))
                 } catch {
                     continuation.resume(throwing: error)
                 }


### PR DESCRIPTION
This PR adds API to the `FIFOQueue` that enables `task`s sent to the queue to execute within a particular `actor`'s context.

The benefits of this API are:
1. Multiple interactions with a single `actor`-conforming type can be executed without requiring multiple suspensions.
2. Only interacting with `async`-decorated properties and methods on a given `actor` requires the `await` keyword, enabling the casual reader to distinguish which tasks will execute synchronously and which may suspend.