### PR TITLE
Make ActorQueue tasks execute on the target actor's execution context

### DIFF
--- a/AsyncQueue.podspec
+++ b/AsyncQueue.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AsyncQueue'
-  s.version  = '0.1.0'
+  s.version  = '0.2.0'
   s.license  = 'MIT'
   s.summary  = 'A queue that enables ordered sending of events from synchronous to asynchronous code.'
   s.homepage = 'https://github.com/dfed/swift-async-queue'

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ func testMainActorTaskOrdering() async {
             await counter.incrementAndAssertCountEquals(iteration)
         })
     }
+    // Wait for all enqueued tasks to finish.
     for task in tasks {
         _ = await task.value
     }
@@ -77,6 +78,7 @@ func testFIFOQueueOrdering() async {
     for iteration in 1...100 {
         counter.incrementAndAssertCountEquals(iteration)
     }
+    // Wait for all enqueued tasks to finish.
     await counter.flushQueue()
 }
 ```
@@ -118,6 +120,7 @@ func testActorQueueOrdering() async {
     for iteration in 1...100 {
         counter.incrementAndAssertCountEquals(iteration)
     }
+    // Wait for all enqueued tasks to finish.
     await counter.flushQueue()
 }
 ```

--- a/README.md
+++ b/README.md
@@ -89,13 +89,16 @@ FIFO execution has a key downside: the queue must wait for all previously enqueu
 
 Use an `ActorQueue` to send ordered asynchronous tasks to an `actor`’s isolated context from nonisolated or synchronous contexts. Tasks sent to an actor queue are guaranteed to begin executing in the order in which they are enqueued. However, unlike a `FIFOQueue`, execution order is guaranteed only until the first [suspension point](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html#ID639) within the enqueued task. An `ActorQueue` executes tasks within the its adopted actor’s isolated context, resulting in `ActorQueue` task execution having the same properties as `actor` code execution: code between suspension points is executed atomically, and tasks sent to a single `ActorQueue` can await results from the queue without deadlocking.
 
-An instance of an `ActorQueue` is designed to be utilized by a single `actor` instance: tasks sent to an `ActorQueue` utilize the isolated context of the queue‘s adopted `actor` to serialize tasks. As such, the lifecycle of any `ActorQueue` should not exceed the lifecycle of its `actor`. It is strongly recommended that an `ActorQueue` be a `let` constant on the adopted `actor`. Additionally, an `actor` utilizing an `ActorQueue` should set the adopted execution context of the queue to `self` within the `actor`’s `init`. Failing to set an adopted execution context prior to enqueuing work on an `ActorQueue` will result in a crash.
+An instance of an `ActorQueue` is designed to be utilized by a single `actor` instance: tasks sent to an `ActorQueue` utilize the isolated context of the queue‘s adopted `actor` to serialize tasks. As such, there are a few requirements that must be met when dealing with an `ActorQueue`:
+1. The lifecycle of any `ActorQueue` should not exceed the lifecycle of its `actor`. It is strongly recommended that an `ActorQueue` be a `let` constant on the adopted `actor`. Enqueuing a task to an `ActorQueue` isntance after its adopted `actor` has been deallocated will result in a crash.
+2. An `actor` utilizing an `ActorQueue` should set the adopted execution context of the queue to `self` within the `actor`’s `init`. Failing to set an adopted execution context prior to enqueuing work on an `ActorQueue` will result in a crash.
 
 An `ActorQueue` can easily enqueue tasks that execute on an actor’s isolated context from a nonisolated context in order:
 ```swift
 func testActorQueueOrdering() async {
     actor Counter {
         init() {
+            // Adopting the execution context in `init` satisfies requirement #2 above.
             queue.adoptExecutionContext(of: self)
         }
 
@@ -113,6 +116,7 @@ func testActorQueueOrdering() async {
         }
 
         private var count = 0
+        // Making the queue a private let constant satisfies requirement #1 above.
         private let queue = ActorQueue<Counter>()
     }
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ While [actors](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html#
 
 ### Executing asynchronous tasks in FIFO order
 
-Use a `FIFOQueue` to execute asynchronous tasks enqueued from a nonisolated context in FIFO order. Tasks sent to one of these queues are guaranteed to begin _and end_ executing in the order in which they are enqueued. A `FIFOQueue` executes tasks in a similar manner to a `DispatchQueue`: enqueued tasks executes atomically, and a `FIFOQueue` task will deadlock the queue if it awaits results from the queue on which it is executing.
+Use a `FIFOQueue` to execute asynchronous tasks enqueued from a nonisolated context in FIFO order. Tasks sent to one of these queues are guaranteed to begin _and end_ executing in the order in which they are enqueued. A `FIFOQueue` executes tasks in a similar manner to a `DispatchQueue`: enqueued tasks executes atomically, and the program will deadlock if a task executing on a `FIFOQueue` awaits results from the queue on which it is executing.
 
 A `FIFOQueue` can easily execute asynchronous tasks from a nonisolated context in FIFO order:
 ```swift

--- a/README.md
+++ b/README.md
@@ -16,19 +16,20 @@ Tasks sent from a synchronous context to an asynchronous context in Swift Concur
 @MainActor
 func testMainActorTaskOrdering() async {
     actor Counter {
-        func increment() -> Int {
+        func incrementAndAssertCountEquals(_ expectedCount: Int) {
             count += 1
-            return count
+            let incrementedCount = count
+            XCTAssertEqual(incrementedCount, expectedCount) // often fails
         }
-        var count = 0
+
+        private var count = 0
     }
 
     let counter = Counter()
     var tasks = [Task<Void, Never>]()
     for iteration in 1...100 {
         tasks.append(Task {
-            let incrementedCount = await counter.increment()
-            XCTAssertEqual(incrementedCount, iteration) // often fails
+            await counter.incrementAndAssertCountEquals(iteration)
         })
     }
     for task in tasks {
@@ -43,109 +44,79 @@ While [actors](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html#
 
 ### Executing asynchronous tasks in FIFO order
 
-Use a `FIFOQueue` to execute asynchronous tasks enqueued from a nonisolated context in FIFO order. Tasks sent to one of these queues are guaranteed to begin _and end_ executing in the order in which they are enqueued.
+Use a `FIFOQueue` to execute asynchronous tasks enqueued from a nonisolated context in FIFO order. Tasks sent to one of these queues are guaranteed to begin _and end_ executing in the order in which they are enqueued. A `FIFOQueue` executes tasks in a similar manner to a `DispatchQueue`: enqueued tasks executes atomically, and a `FIFOQueue` task will deadlock the queue if it awaits results from the queue on which it is executing.
 
-```swift
-let queue = FIFOQueue()
-queue.async {
-    /*
-    `async` context that executes after all other enqueued work is completed.
-    Work enqueued after this task will wait for this task to complete.
-    */
-    try? await Task.sleep(nanoseconds: 1_000_000)
-}
-queue.async {
-    /*
-    This task begins execution once the above one-second sleep completes.
-    */
-}
-await queue.await {
-    /*
-    `async` context that can return a value or throw an error.
-    Executes after all other enqueued work is completed.
-    Work enqueued after this task will wait for this task to complete.
-    */
-}
-```
-
-With a `FIFOQueue` you can easily execute asynchronous tasks from a nonisolated context in FIFO order:
+A `FIFOQueue` can easily execute asynchronous tasks from a nonisolated context in FIFO order:
 ```swift
 func testFIFOQueueOrdering() async {
     actor Counter {
-        func increment() -> Int {
-            count += 1
-            return count
+        nonisolated
+        func incrementAndAssertCountEquals(_ expectedCount: Int) {
+            queue.async {
+                await self.increment()
+                let incrementedCount = await self.count
+                XCTAssertEqual(incrementedCount, expectedCount) // always succeeds
+            }
         }
+
+        nonisolated
+        func flushQueue() async {
+            await queue.await { }
+        }
+
+        func increment() {
+            count += 1
+        }
+
         var count = 0
+
+        private let queue = FIFOQueue()
     }
 
     let counter = Counter()
-    let queue = FIFOQueue()
     for iteration in 1...100 {
-        queue.async {
-            let incrementedCount = await counter.increment()
-            XCTAssertEqual(incrementedCount, iteration) // always succeeds
-        }
+        counter.incrementAndAssertCountEquals(iteration)
     }
-    await queue.await { }
+    await counter.flushQueue()
 }
 ```
 
+FIFO execution has a key downside: the queue must wait for all previously enqueued work – including suspended work – to complete before new work can begin. If you desire new work to start when a prior task suspends, utilize an `ActorQueue`.
+
 ### Sending ordered asynchronous tasks to Actors from a nonisolated context
 
-Use an `ActorQueue` to send ordered asynchronous tasks to an `actor`'s isolated context from a nonisolated and synchronous context. Tasks sent to an actor queue are guaranteed to begin executing in the order in which they are enqueued. Ordering of execution is guaranteed up until the first [suspension point](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html#ID639) within the enqueued task.
+Use an `ActorQueue` to send ordered asynchronous tasks to an `actor`’s isolated context from nonisolated or synchronous contexts. Tasks sent to an actor queue are guaranteed to begin executing in the order in which they are enqueued. However, unlike a `FIFOQueue`, execution order is guaranteed only until the first [suspension point](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html#ID639) within the enqueued task. An `ActorQueue` executes tasks within the its adopted actor’s isolated context, resulting in `ActorQueue` task execution having the same properties as `actor` code execution: code between suspension points is executed atomically, and tasks sent to a single `ActorQueue` can await results from the queue without deadlocking.
 
-```swift
-let queue = ActorQueue()
-queue.setTargetContext(to: actor)
-queue.async { actor in
-    /*
-    `async` context that executes after all other enqueued work has begun executing.
-    Work enqueued after this task will wait for this task to complete or suspend.
-    */
-    await actor.longRunningTask()
-}
-queue.async { actor in
-    /*
-    This task begins execution once the above task suspends due to the long-running task.
-    */
-}
-await queue.await { actor in
-    /*
-    `async` context that can return a value or throw an error.
-    Executes after all other enqueued work has begun executing.
-    Work enqueued after this task will wait for this task to complete or suspend.
-    */
-}
+An instance of an `ActorQueue` is designed to be utilized by a single `actor` instance: tasks sent to an `ActorQueue` utilize the isolated context of the queue‘s adopted `actor` to serialize tasks. As such, the lifecycle of any `ActorQueue` should not exceed the lifecycle of its `actor`. It is strongly recommended that an `ActorQueue` be a `let` constant on the adopted `actor`. Additionally, an `actor` utilizing an `ActorQueue` should set the adopted execution context of the queue to `self` within the `actor`’s `init`. Failing to set an adopted execution context prior to enqueuing work on an `ActorQueue` will result in a crash.
 
-With an `ActorQueue` you can easily begin execution of asynchronous tasks from a nonisolated context in order:
+An `ActorQueue` can easily enqueue tasks that execute on an actor’s isolated context from a nonisolated context in order:
 ```swift
 func testActorQueueOrdering() async {
     actor Counter {
         init() {
-            queue.setTargetContext(to: self)
+            queue.adoptExecutionContext(of: self)
         }
 
         nonisolated
-        func increment(expectedCount: Int) {
+        func incrementAndAssertCountEquals(_ expectedCount: Int) {
             queue.async { myself in
                 myself.count += 1
                 XCTAssertEqual(expectedCount, myself.count) // always succeeds
             }
         }
-        var count = 0
 
         nonisolated
         func flushQueue() async {
             await queue.await { _ in }
         }
 
+        private var count = 0
         private let queue = ActorQueue<Counter>()
     }
 
     let counter = Counter()
     for iteration in 1...100 {
-        counter.increment(expectedCount: iteration)
+        counter.incrementAndAssertCountEquals(iteration)
     }
     await counter.flushQueue()
 }

--- a/Sources/AsyncQueue/ActorQueue.swift
+++ b/Sources/AsyncQueue/ActorQueue.swift
@@ -50,7 +50,7 @@
 /// }
 /// ```
 ///
-/// - Warning: The lifecycle of an `ActorQueue` should not exceed that of the adopted actor.
+/// - Precondition: The lifecycle of an `ActorQueue` must not exceed that of the adopted actor.
 public final class ActorQueue<ActorType: Actor> {
 
     // MARK: Initialization

--- a/Sources/AsyncQueue/ActorQueue.swift
+++ b/Sources/AsyncQueue/ActorQueue.swift
@@ -93,6 +93,9 @@ public final class ActorQueue<ActorType: Actor> {
     /// The scheduled task will not execute until all prior tasks have completed or suspended.
     /// - Parameter task: The task to enqueue. The task's parameter is a reference to the actor whose execution context has been adopted.
     public func async(_ task: @escaping @Sendable (isolated ActorType) async -> Void) {
+        // Crashing here means that this queue is being sent tasks either before an execution context has been set, or
+        // after the execution context has deallocated. An ActorQueue's execution context should be set in the adopted
+        // actor's `init` method, and the ActorQueue should not exceed the lifecycle of the adopted actor.
         taskStreamContinuation.yield(ActorTask(executionContext: executionContext!, task: task))
     }
 
@@ -101,6 +104,9 @@ public final class ActorQueue<ActorType: Actor> {
     /// - Parameter task: The task to enqueue. The task's parameter is a reference to the actor whose execution context has been adopted.
     /// - Returns: The value returned from the enqueued task.
     public func await<T>(_ task: @escaping @Sendable (isolated ActorType) async -> T) async -> T {
+        // Crashing here means that this queue is being sent tasks either before an execution context has been set, or
+        // after the execution context has deallocated. An ActorQueue's execution context should be set in the adopted
+        // actor's `init` method, and the ActorQueue should not exceed the lifecycle of the adopted actor.
         let executionContext = self.executionContext! // Capture/retain the executionContext before suspending.
         return await withUnsafeContinuation { continuation in
             taskStreamContinuation.yield(ActorTask(executionContext: executionContext) { executionContext in
@@ -114,6 +120,9 @@ public final class ActorQueue<ActorType: Actor> {
     /// - Parameter task: The task to enqueue. The task's parameter is a reference to the actor whose execution context has been adopted.
     /// - Returns: The value returned from the enqueued task.
     public func await<T>(_ task: @escaping @Sendable (isolated ActorType) async throws -> T) async throws -> T {
+        // Crashing here means that this queue is being sent tasks either before an execution context has been set, or
+        // after the execution context has deallocated. An ActorQueue's execution context should be set in the adopted
+        // actor's `init` method, and the ActorQueue should not exceed the lifecycle of the adopted actor.
         let executionContext = self.executionContext! // Capture/retain the executionContext before suspending.
         return try await withUnsafeThrowingContinuation { continuation in
             taskStreamContinuation.yield(ActorTask(executionContext: executionContext) { executionContext in

--- a/Sources/AsyncQueue/FIFOQueue.swift
+++ b/Sources/AsyncQueue/FIFOQueue.swift
@@ -59,7 +59,7 @@ public final class FIFOQueue: Sendable {
     }
 
     /// Schedules an asynchronous task for execution and immediately returns.
-    /// The scheduled task will not execute until all prior tasks have completed.
+    /// The scheduled task will not execute until all prior tasks – including suspended tasks – have completed.
     /// - Parameters:
     ///   - isolatedActor: The actor within which the task is isolated.
     ///   - task: The task to enqueue.
@@ -80,7 +80,7 @@ public final class FIFOQueue: Sendable {
     }
 
     /// Schedules an asynchronous task and returns after the task is complete.
-    /// The scheduled task will not execute until all prior tasks have completed.
+    /// The scheduled task will not execute until all prior tasks – including suspended tasks – have completed.
     /// - Parameters:
     ///   - isolatedActor: The actor within which the task is isolated.
     ///   - task: The task to enqueue.
@@ -110,7 +110,7 @@ public final class FIFOQueue: Sendable {
     }
 
     /// Schedules an asynchronous throwing task and returns after the task is complete.
-    /// The scheduled task will not execute until all prior tasks have completed.
+    /// The scheduled task will not execute until all prior tasks – including suspended tasks – have completed.
     /// - Parameters:
     ///   - isolatedActor: The actor within which the task is isolated.
     ///   - task: The task to enqueue.

--- a/Sources/AsyncQueue/FIFOQueue.swift
+++ b/Sources/AsyncQueue/FIFOQueue.swift
@@ -52,7 +52,7 @@ public final class FIFOQueue: Sendable {
     // MARK: Public
 
     /// Schedules an asynchronous task for execution and immediately returns.
-    /// The scheduled task will not execute until all prior tasks have completed.
+    /// The scheduled task will not execute until all prior tasks – including suspended tasks – have completed.
     /// - Parameter task: The task to enqueue.
     public func async(_ task: @escaping @Sendable () async -> Void) {
         taskStreamContinuation.yield(task)
@@ -68,7 +68,7 @@ public final class FIFOQueue: Sendable {
     }
 
     /// Schedules an asynchronous task and returns after the task is complete.
-    /// The scheduled task will not execute until all prior tasks have completed.
+    /// The scheduled task will not execute until all prior tasks – including suspended tasks – have completed.
     /// - Parameter task: The task to enqueue.
     /// - Returns: The value returned from the enqueued task.
     public func await<T>(_ task: @escaping @Sendable () async -> T) async -> T {
@@ -94,7 +94,7 @@ public final class FIFOQueue: Sendable {
     }
 
     /// Schedules an asynchronous throwing task and returns after the task is complete.
-    /// The scheduled task will not execute until all prior tasks have completed.
+    /// The scheduled task will not execute until all prior tasks – including suspended tasks – have completed.
     /// - Parameter task: The task to enqueue.
     /// - Returns: The value returned from the enqueued task.
     public func await<T>(_ task: @escaping @Sendable () async throws -> T) async throws -> T {

--- a/Tests/AsyncQueueTests/ActorQueueTests.swift
+++ b/Tests/AsyncQueueTests/ActorQueueTests.swift
@@ -47,7 +47,7 @@ final class ActorQueueTests: XCTestCase {
         XCTAssertNil(weakCounter)
     }
 
-    func test_async_retainsAdoptedActorUntilQueueFlushes() async {
+    func test_async_retainsAdoptedActorUntilEnqueuedTasksComplete() async {
         let systemUnderTest = ActorQueue<Counter>()
         var counter: Counter? = Counter()
         weak var weakCounter = counter

--- a/Tests/AsyncQueueTests/ActorQueueTests.swift
+++ b/Tests/AsyncQueueTests/ActorQueueTests.swift
@@ -33,7 +33,7 @@ final class ActorQueueTests: XCTestCase {
 
         systemUnderTest = ActorQueue<Counter>()
         counter = Counter()
-        systemUnderTest.setTargetContext(to: counter)
+        systemUnderTest.adoptExecutionContext(of: counter)
     }
 
     // MARK: Behavior Tests
@@ -42,7 +42,7 @@ final class ActorQueueTests: XCTestCase {
         let systemUnderTest = ActorQueue<Counter>()
         var counter: Counter? = Counter()
         weak var weakCounter = counter
-        systemUnderTest.setTargetContext(to: counter!)
+        systemUnderTest.adoptExecutionContext(of: counter!)
         counter = nil
         XCTAssertNil(weakCounter)
     }
@@ -51,7 +51,7 @@ final class ActorQueueTests: XCTestCase {
         let systemUnderTest = ActorQueue<Counter>()
         var counter: Counter? = Counter()
         weak var weakCounter = counter
-        systemUnderTest.setTargetContext(to: counter!)
+        systemUnderTest.adoptExecutionContext(of: counter!)
 
         let semaphore = Semaphore()
         systemUnderTest.async { counter in
@@ -75,7 +75,7 @@ final class ActorQueueTests: XCTestCase {
     func test_async_startsExecutionOfNextTaskAfterSuspension() async {
         let systemUnderTest = ActorQueue<Semaphore>()
         let semaphore = Semaphore()
-        systemUnderTest.setTargetContext(to: semaphore)
+        systemUnderTest.adoptExecutionContext(of: semaphore)
 
         systemUnderTest.async { semaphore in
             await semaphore.wait()
@@ -100,7 +100,7 @@ final class ActorQueueTests: XCTestCase {
 
     func test_async_executesEnqueuedTasksAfterReceiverIsDeallocated() async {
         var systemUnderTest: ActorQueue<Counter>? = ActorQueue()
-        systemUnderTest?.setTargetContext(to: counter)
+        systemUnderTest?.adoptExecutionContext(of: counter)
 
         let expectation = self.expectation(description: #function)
         let semaphore = Semaphore()
@@ -138,7 +138,7 @@ final class ActorQueueTests: XCTestCase {
         let asyncSemaphore = Semaphore()
         let syncSemaphore = Semaphore()
         let systemUnderTest = ActorQueue<Semaphore>()
-        systemUnderTest.setTargetContext(to: syncSemaphore)
+        systemUnderTest.adoptExecutionContext(of: syncSemaphore)
 
         let expectation = self.expectation(description: #function)
         systemUnderTest.async { [reference = referenceHolder.reference] syncSemaphore in


### PR DESCRIPTION
This PR updates the `ActorQueue` API to make `task`s sent to the queue to execute within the target `actor`'s context. This API change is a breaking one, and so we'll be bumping our version to `0.2.0` as part of this change.

Similarly to the benefits discussed in #6, the benefits of running tasks on the target `actor`'s context are:
1. Multiple interactions with a single `actor`-conforming type can be executed without requiring multiple suspensions.
2. Only interacting with `async`-decorated properties and methods on a given `actor` requires the `await` keyword, enabling the casual reader to distinguish which tasks will execute synchronously and which may suspend.

These benefits are particularly important on an `ActorQueue`, where suspension can lead to interleaving of enqueued work.

The downside of this API is that avoiding a retain cycle between an actor queue and the target actor requires the use of an unowned reference and some force unwrapping. See comments below.

Note that this PR is built on top of #8 to avoid conflicts.