### PR TITLE
Resolve Xcode 15 warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.0.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
       - name: Lint Podspec
         run: bundle exec pod lib lint --verbose --fail-fast --swift-version=5.8
   spm-14:
@@ -35,7 +35,7 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.0.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
       - name: Build and Test Framework
         run: Scripts/build.swift ${{ matrix.platforms }}
       - name: Prepare Coverage Reports
@@ -52,6 +52,6 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.0.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
       - name: Build and Test Framework
         run: xcrun swift test -c release -Xswiftc -enable-testing

--- a/Tests/AsyncQueueTests/SemaphoreTests.swift
+++ b/Tests/AsyncQueueTests/SemaphoreTests.swift
@@ -118,7 +118,7 @@ private extension Semaphore {
     /// Enqueues an asynchronous task and increments a counter after the task completes.
     /// This method suspends the caller until the asynchronous task has begun, ensuring ordered execution of enqueued tasks.
     /// - Parameter task: A unit of work that returns work to execute after the task completes and the count is incremented.
-    func enqueueAndCount(using counter: UnsafeCounter, _ task: @escaping @Sendable (isolated Semaphore) async -> ((isolated Semaphore) -> Void)?) async {
+    func enqueueAndCount(using counter: UnsafeCounter, _ task: @escaping @Sendable (isolated Semaphore) async -> (@Sendable (isolated Semaphore) -> Void)?) async {
         // Await the start of the soon-to-be-enqueued `Task` with a continuation.
         await withCheckedContinuation { continuation in
             // Re-enter the semaphore's ordered context but don't wait for the result.


### PR DESCRIPTION
Simple stuff. Xcode 15 caught a non-Sendable boundary crossing issue that Xcode 14 did not in tests.