### PR TITLE
Add support for Linux, macCatalyst, and visionOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         platforms: [
           'iOS_17,watchOS_10',
           'macOS_14,tvOS_17',
+          'macCatalyst_14'
         ]
       fail-fast: false
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,21 @@ jobs:
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
       - name: Build and Test Framework
         run: xcrun swift test -c release -Xswiftc -enable-testing
+  linux:
+    name: "Build and Test on Linux"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup Swift Environment
+        uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: 5.9
+      - name: Build and Test Framework
+        run: swift test -c release --enable-code-coverage -Xswiftc -enable-testing
+      - name: Prepare Coverage Reports
+        run: |
+          llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/release/swift-async-queuePackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/release/codecov/default.profdata > coverage.lcov
+      - name: Upload Coverage Reports
+        if: success()
+        uses: codecov/codecov-action@v3

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,8 @@ let package = Package(
         .iOS(.v13),
         .tvOS(.v13),
         .watchOS(.v6),
+        .macCatalyst(.v13),
+        .visionOS(.v1),
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # swift-async-queue
 [![CI Status](https://img.shields.io/github/actions/workflow/status/dfed/swift-async-queue/ci.yml?branch=main)](https://github.com/dfed/swift-async-queue/actions?query=workflow%3ACI+branch%3Amain)
-[![Swift Package Manager compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://github.com/apple/swift-package-manager)
 [![codecov](https://codecov.io/gh/dfed/swift-async-queue/branch/main/graph/badge.svg?token=nZBHcZZ63F)](https://codecov.io/gh/dfed/swift-async-queue)
-[![Version](https://img.shields.io/cocoapods/v/AsyncQueue.svg)](https://cocoapods.org/pods/AsyncQueue)
-[![License](https://img.shields.io/cocoapods/l/AsyncQueue.svg)](https://cocoapods.org/pods/AsyncQueue)
-[![Platform](https://img.shields.io/cocoapods/p/AsyncQueue.svg)](https://cocoapods.org/pods/AsyncQueue)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://spdx.org/licenses/MIT.html)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fdfed%2Fswift-async-queue%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/dfed/swift-async-queue)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fdfed%2Fswift-async-queue%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/dfed/swift-async-queue)
 
 A library of queues that enable sending ordered tasks from synchronous to asynchronous contexts.
 

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -36,6 +36,8 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
     case macOS_12
     case macOS_13
     case macOS_14
+    case macCatalyst_13
+    case macCatalyst_14
     case watchOS_6
     case watchOS_7
     case watchOS_8
@@ -70,7 +72,9 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
              .macOS_11,
              .macOS_12,
              .macOS_13,
-             .macOS_14:
+             .macOS_14,
+             .macCatalyst_13,
+             .macCatalyst_14:
             return "platform=OS X"
 
         case .watchOS_6:
@@ -112,6 +116,10 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
             return "macosx13.3"
         case .macOS_14:
             return "macosx14.0"
+        case .macCatalyst_13:
+            return "macosx13.3"
+        case .macCatalyst_14:
+            return "macosx14.0"
 
         case .watchOS_6,
              .watchOS_7,
@@ -138,7 +146,9 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
              .macOS_11,
              .macOS_12,
              .macOS_13,
-             .macOS_14:
+             .macOS_14,
+             .macCatalyst_13,
+             .macCatalyst_14:
             return true
 
         case .watchOS_6,


### PR DESCRIPTION
When we merge, I'll need to add the linux check and macCatalyst checks as required on all PRs.

We'll add visionOS checks to CI once Xcode 15.2 is generally available, but for now I've run tests locally on a beta install of Xcode 15.2.