### PR TITLE
Support Swift 6

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "swift-async-queue",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+        .macCatalyst(.v13),
+        .visionOS(.v1),
+    ],
+    products: [
+        .library(
+            name: "AsyncQueue",
+            targets: ["AsyncQueue"]),
+    ],
+    targets: [
+        .target(
+            name: "AsyncQueue",
+            dependencies: [],
+            swiftSettings: [
+                .swiftLanguageVersion(.v6),
+            ]),
+        .testTarget(
+            name: "AsyncQueueTests",
+            dependencies: ["AsyncQueue"],
+            swiftSettings: [
+                .swiftLanguageVersion(.v6),
+            ]),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A library of queues that enable sending ordered tasks from synchronous to asynch
 
 ## Task Ordering and Swift Concurrency
 
-Tasks sent from a synchronous context to an asynchronous context in Swift Concurrency are inherently unordered. Consider the following test:
+Tasks sent from a synchronous context to an asynchronous context in Swift Concurrency prior to Swift 6 are inherently unordered. Consider the following test:
 
 ```swift
 @MainActor
@@ -40,7 +40,7 @@ func testMainActorTaskOrdering() async {
 
 Despite the spawned `Task` inheriting the serial `@MainActor` execution context, the ordering of the scheduled asynchronous work is not guaranteed.
 
-While [actors](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html#ID645) are great at serializing tasks, there is no simple way in the standard Swift library to send ordered tasks to them from a synchronous context.
+While [actors](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html#ID645) are great at serializing tasks, there is no simple way in the standard Swift library prior to Swift 6 to send ordered tasks to them from a synchronous context.
 
 ### Executing asynchronous tasks in FIFO order
 


### PR DESCRIPTION
Gets us running well in Swift 6 language mode.

We'll add CI when Xcode 16 is in CI. For now I'm testing locally.