### PR TITLE
Remove need for ActorQueueSynchronization

### DIFF
--- a/Sources/AsyncQueue/ActorQueue.swift
+++ b/Sources/AsyncQueue/ActorQueue.swift
@@ -78,7 +78,7 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
 
         actor.execute { [taskStream] _ in
             func beginExecuting(
-                _ operation: sending @escaping (isolated ActorType) async -> Void,
+                _ operation: @escaping (isolated ActorType) async -> Void,
                 in context: isolated ActorType
             ) {
                 // In Swift 6, a `Task` enqueued from an actor begins executing immediately on that actor.

--- a/Sources/AsyncQueue/ActorQueue.swift
+++ b/Sources/AsyncQueue/ActorQueue.swift
@@ -89,6 +89,8 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
             }
 
             for await actorTask in taskStream {
+                // The compiler does not have a guarantee that `actor === actorTask.executionContext`, so we must `await`.
+                // In practice, however, that condition is always true, and therefore we do not end up suspending here.
                 await beginExecuting(
                     actorTask.task,
                     in: actorTask.executionContext

--- a/Sources/AsyncQueue/ActorQueue.swift
+++ b/Sources/AsyncQueue/ActorQueue.swift
@@ -64,7 +64,7 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
             _ operation: sending @escaping (isolated ActorType) async -> Void,
             in context: isolated ActorType
         ) {
-            // In Swift 6, a `Task` enqueued from an actor begins executing immediately on that actor.
+            // In Swift 6, a `Task` enqueued from an actor begins executing immediately on that global actor.
             // Since we're running on our actor's context already, we can just dispatch a Task to get first-enqueued-first-start task execution.
             Task {
                 await operation(context)
@@ -73,7 +73,7 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
 
         Task {
             // In an ideal world, we would isolate this `for await` loop to the `ActorType`.
-            // However, there's no good way to do that without retaining the actor and creating a cycle.
+            // However, there's no good way to do that just yet.
             for await actorTask in taskStream {
                 // Await switching to the ActorType context.
                 await beginExecuting(

--- a/Sources/AsyncQueue/ActorQueue.swift
+++ b/Sources/AsyncQueue/ActorQueue.swift
@@ -64,7 +64,7 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
             _ operation: sending @escaping (isolated ActorType) async -> Void,
             in context: isolated ActorType
         ) {
-            // In Swift 6, a `Task` enqueued from an actor begins executing immediately on that global actor.
+            // In Swift 6, a `Task` enqueued from an actor begins executing immediately on that actor.
             // Since we're running on our actor's context already, we can just dispatch a Task to get first-enqueued-first-start task execution.
             Task {
                 await operation(context)
@@ -73,7 +73,7 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
 
         Task {
             // In an ideal world, we would isolate this `for await` loop to the `ActorType`.
-            // However, there's no good way to do that just yet.
+            // However, there's no good way to do that without retaining the actor and creating a cycle.
             for await actorTask in taskStream {
                 // Await switching to the ActorType context.
                 await beginExecuting(

--- a/Sources/AsyncQueue/ActorQueue.swift
+++ b/Sources/AsyncQueue/ActorQueue.swift
@@ -57,31 +57,7 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
 
     /// Instantiates an actor queue.
     public init() {
-        let (taskStream, taskStreamContinuation) = AsyncStream<ActorTask>.makeStream()
-        self.taskStreamContinuation = taskStreamContinuation
-
-        func beginExecuting(
-            _ operation: sending @escaping (isolated ActorType) async -> Void,
-            in context: isolated ActorType
-        ) {
-            // In Swift 6, a `Task` enqueued from an actor begins executing immediately on that global actor.
-            // Since we're running on our actor's context already, we can just dispatch a Task to get first-enqueued-first-start task execution.
-            Task {
-                await operation(context)
-            }
-        }
-
-        Task {
-            // In an ideal world, we would isolate this `for await` loop to the `ActorType`.
-            // However, there's no good way to do that just yet.
-            for await actorTask in taskStream {
-                // Await switching to the ActorType context.
-                await beginExecuting(
-                    actorTask.task,
-                    in: actorTask.executionContext
-                )
-            }
-        }
+        (taskStream, taskStreamContinuation) = AsyncStream<ActorTask>.makeStream()
     }
 
     deinit {
@@ -95,10 +71,30 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
     /// **Must be called prior to enqueuing any work on the receiver.**
     ///
     /// - Parameter actor: The actor on which the queue's task will execute. This parameter is not retained by the receiver.
-    /// - Warning: Calling this method more than once will result in an assertion failure.
+    /// - Precondition: Calling this method more than once will result in a precondition failure.
     public func adoptExecutionContext(of actor: ActorType) {
-        assert(weakExecutionContext == nil) // Adopting multiple executionContexts on the same queue is API abuse.
+        precondition(weakExecutionContext == nil) // Adopting multiple executionContexts on the same queue is API abuse.
         weakExecutionContext = actor
+
+        actor.execute { [taskStream] _ in
+            func beginExecuting(
+                _ operation: sending @escaping (isolated ActorType) async -> Void,
+                in context: isolated ActorType
+            ) {
+                // In Swift 6, a `Task` enqueued from an actor begins executing immediately on that actor.
+                // Since we're running on our actor's context due to the isolated parmater, we can just dispatch a Task to get first-enqueued-first-start task execution.
+                Task {
+                    await operation(context)
+                }
+            }
+
+            for await actorTask in taskStream {
+                await beginExecuting(
+                    actorTask.task,
+                    in: actorTask.executionContext
+                )
+            }
+        }
     }
 
     /// Schedules an asynchronous task for execution and immediately returns.
@@ -140,6 +136,7 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
 
     // MARK: Private
 
+    private let taskStream: AsyncStream<ActorQueue<ActorType>.ActorTask>
     private let taskStreamContinuation: AsyncStream<ActorTask>.Continuation
 
     /// The actor on whose isolated context our tasks run, force-unwrapped.
@@ -161,5 +158,16 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
     private struct ActorTask {
         let executionContext: ActorType
         let task: @Sendable (isolated ActorType) async -> Void
+    }
+}
+
+extension Actor {
+    nonisolated
+    func execute(
+        _ task: @escaping @Sendable (isolated Self?) async -> Void
+    ) {
+        Task {
+            await task(nil)
+        }
     }
 }

--- a/Sources/AsyncQueue/ActorQueue.swift
+++ b/Sources/AsyncQueue/ActorQueue.swift
@@ -78,7 +78,7 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
 
         actor.execute { [taskStream] _ in
             func beginExecuting(
-                _ operation: @escaping (isolated ActorType) async -> Void,
+                _ operation: sending @escaping (isolated ActorType) async -> Void,
                 in context: isolated ActorType
             ) {
                 // In Swift 6, a `Task` enqueued from an actor begins executing immediately on that actor.

--- a/Sources/AsyncQueue/ActorQueue.swift
+++ b/Sources/AsyncQueue/ActorQueue.swift
@@ -89,8 +89,6 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
             }
 
             for await actorTask in taskStream {
-                // The compiler does not have a guarantee that `actor === actorTask.executionContext`, so we must `await`.
-                // In practice, however, that condition is always true, and therefore we do not end up suspending here.
                 await beginExecuting(
                     actorTask.task,
                     in: actorTask.executionContext

--- a/Sources/AsyncQueue/ActorQueue.swift
+++ b/Sources/AsyncQueue/ActorQueue.swift
@@ -60,15 +60,26 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
         let (taskStream, taskStreamContinuation) = AsyncStream<ActorTask>.makeStream()
         self.taskStreamContinuation = taskStreamContinuation
 
-        Task { @ActorQueueSynchronization in
+        func beginExecuting(
+            _ operation: sending @escaping (isolated ActorType) async -> Void,
+            in context: isolated ActorType
+        ) {
+            // In Swift 6, a `Task` enqueued from an actor begins executing immediately on that global actor.
+            // Since we're running on our actor's context already, we can just dispatch a Task to get first-enqueued-first-start task execution.
+            Task {
+                await operation(context)
+            }
+        }
+
+        Task {
+            // In an ideal world, we would isolate this `for await` loop to the `ActorType`.
+            // However, there's no good way to do that just yet.
             for await actorTask in taskStream {
-                // In Swift 6, a `Task` enqueued from a global actor begins executing immediately on that global actor.
-                // Since we're running on a global actor already, we can just dispatch a Task to get first-enqueued-first-start
-                // task execution. In an ideal world, we wouldn't need a global actor and would isolate this `for await` loop on
-                // the `ActorType`. However, there's no good way to do that just yet.
-                Task {
-                    await actorTask.task(actorTask.executionContext)
-                }
+                // Await switching to the ActorType context.
+                await beginExecuting(
+                    actorTask.task,
+                    in: actorTask.executionContext
+                )
             }
         }
     }
@@ -151,11 +162,4 @@ public final class ActorQueue<ActorType: Actor>: @unchecked Sendable {
         let executionContext: ActorType
         let task: @Sendable (isolated ActorType) async -> Void
     }
-}
-
-/// A global actor used for synchronizing task execution.
-@globalActor
-private struct ActorQueueSynchronization {
-    fileprivate actor Synchronization {}
-    fileprivate static let shared = Synchronization()
 }


### PR DESCRIPTION
We don't need to bounce through a global queue in order to ensure FIFS (first-enqueued-first-start) behavior in our ActorQueue. Instead, we just can make the async for loop await switching to the ActorType's context.

This PR is unlikely to affect performance. This PR should make this code a bit easier to follow, however.