### PR TITLE
Adopt Swift Testing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
     products: [
         .library(
             name: "AsyncQueue",
-            targets: ["AsyncQueue"]),
+            targets: ["AsyncQueue"]
+        ),
     ],
     targets: [
         .target(
@@ -24,12 +25,14 @@ let package = Package(
             dependencies: [],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
-            ]),
+            ]
+        ),
         .testTarget(
             name: "AsyncQueueTests",
             dependencies: ["AsyncQueue"],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
-            ]),
+            ]
+        ),
     ]
 )

--- a/Tests/AsyncQueueTests/ActorQueueTests.swift
+++ b/Tests/AsyncQueueTests/ActorQueueTests.swift
@@ -113,6 +113,7 @@ struct ActorQueueTests {
         }
     }
 
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @MainActor
     @Test func test_enqueue_executesEnqueuedTasksAfterReceiverIsDeallocated() async {
         var systemUnderTest: ActorQueue<Counter>? = ActorQueue()
@@ -135,6 +136,7 @@ struct ActorQueueTests {
         await expectation.fulfillment(within: .seconds(1))
     }
 
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_enqueue_doesNotRetainTaskAfterExecution() async {
         final class Reference: Sendable {}
         final class ReferenceHolder: @unchecked Sendable {

--- a/Tests/AsyncQueueTests/ActorQueueTests.swift
+++ b/Tests/AsyncQueueTests/ActorQueueTests.swift
@@ -133,7 +133,7 @@ struct ActorQueueTests {
         #expect(queue == nil)
         // Signal the semaphore to unlock the enqueued tasks.
         await semaphore.signal()
-        await expectation.fulfillment(within: .seconds(5))
+        await expectation.fulfillment(within: .seconds(10))
     }
 
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -178,7 +178,7 @@ struct ActorQueueTests {
         // Allow the enqueued task to complete.
         await asyncSemaphore.signal()
         // Make sure the task has completed.
-        await expectation.fulfillment(within: .seconds(5))
+        await expectation.fulfillment(within: .seconds(10))
 
         #expect(referenceHolder.weakReference == nil)
     }

--- a/Tests/AsyncQueueTests/ActorQueueTests.swift
+++ b/Tests/AsyncQueueTests/ActorQueueTests.swift
@@ -133,7 +133,7 @@ struct ActorQueueTests {
         #expect(queue == nil)
         // Signal the semaphore to unlock the enqueued tasks.
         await semaphore.signal()
-        await expectation.fulfillment(within: .seconds(1))
+        await expectation.fulfillment(within: .seconds(5))
     }
 
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -178,7 +178,7 @@ struct ActorQueueTests {
         // Allow the enqueued task to complete.
         await asyncSemaphore.signal()
         // Make sure the task has completed.
-        await expectation.fulfillment(within: .seconds(1))
+        await expectation.fulfillment(within: .seconds(5))
 
         #expect(referenceHolder.weakReference == nil)
     }

--- a/Tests/AsyncQueueTests/ActorQueueTests.swift
+++ b/Tests/AsyncQueueTests/ActorQueueTests.swift
@@ -113,8 +113,6 @@ struct ActorQueueTests {
         }
     }
 
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-    @MainActor
     @Test func test_enqueue_executesEnqueuedTasksAfterReceiverIsDeallocated() async {
         var systemUnderTest: ActorQueue<Counter>? = ActorQueue()
         systemUnderTest?.adoptExecutionContext(of: counter)
@@ -133,10 +131,9 @@ struct ActorQueueTests {
         #expect(queue == nil)
         // Signal the semaphore to unlock the enqueued tasks.
         await semaphore.signal()
-        await expectation.fulfillment(within: .seconds(10))
+        await expectation.fulfillment(withinSeconds: 10)
     }
 
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_enqueue_doesNotRetainTaskAfterExecution() async {
         final class Reference: Sendable {}
         final class ReferenceHolder: @unchecked Sendable {
@@ -178,7 +175,7 @@ struct ActorQueueTests {
         // Allow the enqueued task to complete.
         await asyncSemaphore.signal()
         // Make sure the task has completed.
-        await expectation.fulfillment(within: .seconds(10))
+        await expectation.fulfillment(withinSeconds: 10)
 
         #expect(referenceHolder.weakReference == nil)
     }

--- a/Tests/AsyncQueueTests/ExpectationTests.swift
+++ b/Tests/AsyncQueueTests/ExpectationTests.swift
@@ -26,7 +26,6 @@ struct ExpectationTests {
 
     // MARK: Behavior Tests
 
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_fulfill_triggersExpectation() async {
         await confirmation { confirmation in
             let systemUnderTest = Expectation(
@@ -40,7 +39,6 @@ struct ExpectationTests {
         }
     }
 
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_fulfill_triggersExpectationOnceWhenCalledTwiceAndExpectedCountIsTwo() async {
         await confirmation { confirmation in
             let systemUnderTest = Expectation(
@@ -55,7 +53,6 @@ struct ExpectationTests {
         }
     }
 
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_fulfill_triggersExpectationWhenExpectedCountIsZero() async {
         await confirmation { confirmation in
             let systemUnderTest = Expectation(
@@ -69,19 +66,17 @@ struct ExpectationTests {
         }
     }
 
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_fulfillment_doesNotWaitIfAlreadyFulfilled() async {
         let systemUnderTest = Expectation(expectedCount: 0)
-        await systemUnderTest.fulfillment(within: .seconds(10))
+        await systemUnderTest.fulfillment(withinSeconds: 10)
     }
 
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @MainActor // Global actor ensures Task ordering.
     @Test func test_fulfillment_waitsForFulfillment() async {
         let systemUnderTest = Expectation(expectedCount: 1)
         var hasFulfilled = false
         let wait = Task {
-            await systemUnderTest.fulfillment(within: .seconds(10))
+            await systemUnderTest.fulfillment(withinSeconds: 10)
             #expect(hasFulfilled)
         }
         Task {
@@ -91,7 +86,6 @@ struct ExpectationTests {
         await wait.value
     }
 
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_fulfillment_triggersFalseExpectationWhenItTimesOut() async {
         await confirmation { confirmation in
             let systemUnderTest = Expectation(
@@ -101,7 +95,7 @@ struct ExpectationTests {
                     confirmation()
                 }
             )
-            await systemUnderTest.fulfillment(within: .zero)
+            await systemUnderTest.fulfillment(withinSeconds: 0)
         }
     }
 }

--- a/Tests/AsyncQueueTests/ExpectationTests.swift
+++ b/Tests/AsyncQueueTests/ExpectationTests.swift
@@ -20,7 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Foundation
 import Testing
 
 struct ExpectationTests {
@@ -73,21 +72,17 @@ struct ExpectationTests {
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_fulfillment_doesNotWaitIfAlreadyFulfilled() async {
         let systemUnderTest = Expectation(expectedCount: 0)
-        let date = Date()
         await systemUnderTest.fulfillment(within: .seconds(10))
-        #expect(-date.timeIntervalSinceNow < 10)
     }
 
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @MainActor // Global actor ensures Task ordering.
-    @Test func test_fulfillment_waitsWithinTimeoutForFulfillment() async {
+    @Test func test_fulfillment_waitsForFulfillment() async {
         let systemUnderTest = Expectation(expectedCount: 1)
-        let date = Date()
         var hasFulfilled = false
         let wait = Task {
             await systemUnderTest.fulfillment(within: .seconds(10))
             #expect(hasFulfilled)
-            #expect(-date.timeIntervalSinceNow < 10)
         }
         Task {
             systemUnderTest.fulfill()

--- a/Tests/AsyncQueueTests/ExpectationTests.swift
+++ b/Tests/AsyncQueueTests/ExpectationTests.swift
@@ -75,7 +75,7 @@ struct ExpectationTests {
         let systemUnderTest = Expectation(expectedCount: 0)
         let date = Date()
         await systemUnderTest.fulfillment(within: .seconds(10))
-        #expect(-date.timeIntervalSinceNow < 1)
+        #expect(-date.timeIntervalSinceNow < 10)
     }
 
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -87,7 +87,7 @@ struct ExpectationTests {
         let wait = Task {
             await systemUnderTest.fulfillment(within: .seconds(10))
             #expect(hasFulfilled)
-            #expect(-date.timeIntervalSinceNow < 1)
+            #expect(-date.timeIntervalSinceNow < 10)
         }
         Task {
             systemUnderTest.fulfill()

--- a/Tests/AsyncQueueTests/ExpectationTests.swift
+++ b/Tests/AsyncQueueTests/ExpectationTests.swift
@@ -27,6 +27,7 @@ struct ExpectationTests {
 
     // MARK: Behavior Tests
 
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_fulfill_triggersExpectation() async {
         await confirmation { confirmation in
             let systemUnderTest = Expectation(
@@ -40,6 +41,7 @@ struct ExpectationTests {
         }
     }
 
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_fulfill_triggersExpectationOnceWhenCalledTwiceAndExpectedCountIsTwo() async {
         await confirmation { confirmation in
             let systemUnderTest = Expectation(
@@ -54,6 +56,7 @@ struct ExpectationTests {
         }
     }
 
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_fulfill_triggersExpectationWhenExpectedCountIsZero() async {
         await confirmation { confirmation in
             let systemUnderTest = Expectation(
@@ -67,6 +70,7 @@ struct ExpectationTests {
         }
     }
 
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_fulfillment_doesNotWaitIfAlreadyFulfilled() async {
         let systemUnderTest = Expectation(expectedCount: 0)
         let date = Date()
@@ -74,6 +78,7 @@ struct ExpectationTests {
         #expect(-date.timeIntervalSinceNow < 1)
     }
 
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @MainActor // Global actor ensures Task ordering.
     @Test func test_fulfillment_waitsWithinTimeoutForFulfillment() async {
         let systemUnderTest = Expectation(expectedCount: 1)
@@ -91,6 +96,7 @@ struct ExpectationTests {
         await wait.value
     }
 
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_fulfillment_triggersFalseExpectationWhenItTimesOut() async {
         await confirmation { confirmation in
             let systemUnderTest = Expectation(

--- a/Tests/AsyncQueueTests/ExpectationTests.swift
+++ b/Tests/AsyncQueueTests/ExpectationTests.swift
@@ -1,0 +1,106 @@
+// MIT License
+//
+// Copyright (c) 2024 Dan Federman
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import Testing
+
+struct ExpectationTests {
+
+    // MARK: Behavior Tests
+
+    @Test func test_fulfill_triggersExpectation() async {
+        await confirmation { confirmation in
+            let systemUnderTest = Expectation(
+                expectedCount: 1,
+                expect: { expectation, _, _ in
+                    #expect(expectation)
+                    confirmation()
+                }
+            )
+            await systemUnderTest.fulfill().value
+        }
+    }
+
+    @Test func test_fulfill_triggersExpectationOnceWhenCalledTwiceAndExpectedCountIsTwo() async {
+        await confirmation { confirmation in
+            let systemUnderTest = Expectation(
+                expectedCount: 2,
+                expect: { expectation, _, _ in
+                    #expect(expectation)
+                    confirmation()
+                }
+            )
+            await systemUnderTest.fulfill().value
+            await systemUnderTest.fulfill().value
+        }
+    }
+
+    @Test func test_fulfill_triggersExpectationWhenExpectedCountIsZero() async {
+        await confirmation { confirmation in
+            let systemUnderTest = Expectation(
+                expectedCount: 0,
+                expect: { expectation, _, _ in
+                    #expect(!expectation)
+                    confirmation()
+                }
+            )
+            await systemUnderTest.fulfill().value
+        }
+    }
+
+    @Test func test_fulfillment_doesNotWaitIfAlreadyFulfilled() async {
+        let systemUnderTest = Expectation(expectedCount: 0)
+        let date = Date()
+        await systemUnderTest.fulfillment(within: .seconds(10))
+        #expect(-date.timeIntervalSinceNow < 1)
+    }
+
+    @MainActor // Global actor ensures Task ordering.
+    @Test func test_fulfillment_waitsWithinTimeoutForFulfillment() async {
+        let systemUnderTest = Expectation(expectedCount: 1)
+        let date = Date()
+        var hasFulfilled = false
+        let wait = Task {
+            await systemUnderTest.fulfillment(within: .seconds(10))
+            #expect(hasFulfilled)
+            #expect(-date.timeIntervalSinceNow < 1)
+        }
+        Task {
+            systemUnderTest.fulfill()
+            hasFulfilled = true
+        }
+        await wait.value
+    }
+
+    @Test func test_fulfillment_triggersFalseExpectationWhenItTimesOut() async {
+        await confirmation { confirmation in
+            let systemUnderTest = Expectation(
+                expectedCount: 1,
+                expect: { expectation, _, _ in
+                    #expect(!expectation)
+                    confirmation()
+                }
+            )
+            await systemUnderTest.fulfillment(within: .zero)
+        }
+    }
+}

--- a/Tests/AsyncQueueTests/FIFOQueueTests.swift
+++ b/Tests/AsyncQueueTests/FIFOQueueTests.swift
@@ -187,7 +187,6 @@ struct FIFOQueueTests {
         await systemUnderTest.enqueueAndWait { /* Drain the queue */ }
     }
 
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_enqueue_executesAfterReceiverIsDeallocated() async {
         var systemUnderTest: FIFOQueue? = FIFOQueue()
         let counter = Counter()
@@ -210,10 +209,9 @@ struct FIFOQueueTests {
         // Signal the semaphore to unlock the remaining enqueued tasks.
         await semaphore.signal()
 
-        await expectation.fulfillment(within: .seconds(10))
+        await expectation.fulfillment(withinSeconds: 10)
     }
 
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_enqueueOn_executesAfterReceiverIsDeallocated() async {
         var systemUnderTest: FIFOQueue? = FIFOQueue()
         let counter = Counter()
@@ -236,7 +234,7 @@ struct FIFOQueueTests {
         // Signal the semaphore to unlock the remaining enqueued tasks.
         await semaphore.signal()
 
-        await expectation.fulfillment(within: .seconds(10))
+        await expectation.fulfillment(withinSeconds: 10)
     }
 
     @Test func test_enqueue_doesNotRetainTaskAfterExecution() async {

--- a/Tests/AsyncQueueTests/FIFOQueueTests.swift
+++ b/Tests/AsyncQueueTests/FIFOQueueTests.swift
@@ -187,6 +187,7 @@ struct FIFOQueueTests {
         await systemUnderTest.enqueueAndWait { /* Drain the queue */ }
     }
 
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_enqueue_executesAfterReceiverIsDeallocated() async {
         var systemUnderTest: FIFOQueue? = FIFOQueue()
         let counter = Counter()
@@ -212,6 +213,7 @@ struct FIFOQueueTests {
         await expectation.fulfillment(within: .seconds(1))
     }
 
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_enqueueOn_executesAfterReceiverIsDeallocated() async {
         var systemUnderTest: FIFOQueue? = FIFOQueue()
         let counter = Counter()

--- a/Tests/AsyncQueueTests/FIFOQueueTests.swift
+++ b/Tests/AsyncQueueTests/FIFOQueueTests.swift
@@ -210,7 +210,7 @@ struct FIFOQueueTests {
         // Signal the semaphore to unlock the remaining enqueued tasks.
         await semaphore.signal()
 
-        await expectation.fulfillment(within: .seconds(5))
+        await expectation.fulfillment(within: .seconds(10))
     }
 
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -236,7 +236,7 @@ struct FIFOQueueTests {
         // Signal the semaphore to unlock the remaining enqueued tasks.
         await semaphore.signal()
 
-        await expectation.fulfillment(within: .seconds(5))
+        await expectation.fulfillment(within: .seconds(10))
     }
 
     @Test func test_enqueue_doesNotRetainTaskAfterExecution() async {

--- a/Tests/AsyncQueueTests/FIFOQueueTests.swift
+++ b/Tests/AsyncQueueTests/FIFOQueueTests.swift
@@ -210,7 +210,7 @@ struct FIFOQueueTests {
         // Signal the semaphore to unlock the remaining enqueued tasks.
         await semaphore.signal()
 
-        await expectation.fulfillment(within: .seconds(1))
+        await expectation.fulfillment(within: .seconds(5))
     }
 
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -236,7 +236,7 @@ struct FIFOQueueTests {
         // Signal the semaphore to unlock the remaining enqueued tasks.
         await semaphore.signal()
 
-        await expectation.fulfillment(within: .seconds(1))
+        await expectation.fulfillment(within: .seconds(5))
     }
 
     @Test func test_enqueue_doesNotRetainTaskAfterExecution() async {

--- a/Tests/AsyncQueueTests/FIFOQueueTests.swift
+++ b/Tests/AsyncQueueTests/FIFOQueueTests.swift
@@ -341,9 +341,29 @@ struct FIFOQueueTests {
         #expect(expectedValue == returnedValue)
     }
 
+    @Test func test_enqueueAndWait_throwing_canReturn() async throws {
+        let expectedValue = UUID()
+        @Sendable func throwingMethod() throws {}
+        let returnedValue = try await systemUnderTest.enqueueAndWait {
+            try throwingMethod()
+            return expectedValue
+        }
+        #expect(expectedValue == returnedValue)
+    }
+
     @Test func test_enqueueAndWaitOn_canReturn() async {
         let expectedValue = UUID()
         let returnedValue = await systemUnderTest.enqueueAndWait(on: Counter()) { _ in expectedValue }
+        #expect(expectedValue == returnedValue)
+    }
+
+    @Test func test_enqueueAndWaitOn_throwing_canReturn() async throws {
+        let expectedValue = UUID()
+        @Sendable func throwingMethod() throws {}
+        let returnedValue = try await systemUnderTest.enqueueAndWait(on: Counter()) { _ in
+            try throwingMethod()
+            return expectedValue
+        }
         #expect(expectedValue == returnedValue)
     }
 

--- a/Tests/AsyncQueueTests/MainActorQueueTests.swift
+++ b/Tests/AsyncQueueTests/MainActorQueueTests.swift
@@ -124,7 +124,7 @@ struct MainActorQueueTests {
         // Allow the enqueued task to complete.
         await asyncSemaphore.signal()
         // Make sure the task has completed.
-        await expectation.fulfillment(within: .seconds(1))
+        await expectation.fulfillment(within: .seconds(5))
 
         #expect(referenceHolder.weakReference == nil)
     }

--- a/Tests/AsyncQueueTests/MainActorQueueTests.swift
+++ b/Tests/AsyncQueueTests/MainActorQueueTests.swift
@@ -124,7 +124,7 @@ struct MainActorQueueTests {
         // Allow the enqueued task to complete.
         await asyncSemaphore.signal()
         // Make sure the task has completed.
-        await expectation.fulfillment(within: .seconds(5))
+        await expectation.fulfillment(within: .seconds(10))
 
         #expect(referenceHolder.weakReference == nil)
     }

--- a/Tests/AsyncQueueTests/MainActorQueueTests.swift
+++ b/Tests/AsyncQueueTests/MainActorQueueTests.swift
@@ -82,7 +82,6 @@ struct MainActorQueueTests {
         }
     }
 
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_enqueue_doesNotRetainTaskAfterExecution() async {
         final class Reference: Sendable {}
         final class ReferenceHolder: @unchecked Sendable {
@@ -124,7 +123,7 @@ struct MainActorQueueTests {
         // Allow the enqueued task to complete.
         await asyncSemaphore.signal()
         // Make sure the task has completed.
-        await expectation.fulfillment(within: .seconds(10))
+        await expectation.fulfillment(withinSeconds: 10)
 
         #expect(referenceHolder.weakReference == nil)
     }

--- a/Tests/AsyncQueueTests/MainActorQueueTests.swift
+++ b/Tests/AsyncQueueTests/MainActorQueueTests.swift
@@ -20,35 +20,28 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import AsyncQueue
 
-final class MainActorQueueTests: XCTestCase {
-
-    // MARK: XCTestCase
-
-    override func setUp() async throws {
-        try await super.setUp()
-
-        systemUnderTest = MainActorQueue()
-        counter = Counter()
-    }
-
+struct MainActorQueueTests {
     // MARK: Behavior Tests
 
-    func test_shared_returnsSameInstance() async {
-        XCTAssertTrue(MainActorQueue.shared === MainActorQueue.shared)
+    @Test func test_shared_returnsSameInstance() async {
+        #expect(MainActorQueue.shared === MainActorQueue.shared)
     }
 
-    func test_enqueue_executesOnMainThread() async {
+    @Test func test_enqueue_executesOnMainThread() async {
+        let key: DispatchSpecificKey<Void> = .init()
+        DispatchQueue.main.setSpecific(key: key, value: ())
         systemUnderTest.enqueue {
-            XCTAssertTrue(Thread.isMainThread)
+            #expect(DispatchQueue.main.getSpecific(key: key) != nil)
         }
         await systemUnderTest.enqueueAndWait { /* Drain the queue */ }
     }
 
-    func test_enqueue_sendsEventsInOrder() async {
+    @Test func test_enqueue_sendsEventsInOrder() async {
         for iteration in 1...1_000 {
             systemUnderTest.enqueue { [counter] in
                 await counter.incrementAndExpectCount(equals: iteration)
@@ -57,7 +50,7 @@ final class MainActorQueueTests: XCTestCase {
         await systemUnderTest.enqueueAndWait { /* Drain the queue */ }
     }
 
-    func test_enqueue_startsExecutionOfNextTaskAfterSuspension() async {
+    @Test func test_enqueue_startsExecutionOfNextTaskAfterSuspension() async {
         let semaphore = Semaphore()
 
         systemUnderTest.enqueue {
@@ -72,13 +65,15 @@ final class MainActorQueueTests: XCTestCase {
         await systemUnderTest.enqueueAndWait { /* Drain the queue */ }
     }
 
-    func test_enqueueAndWait_executesOnMainThread() async {
+    @Test func test_enqueueAndWait_executesOnMainThread() async {
+        let key: DispatchSpecificKey<Void> = .init()
+        DispatchQueue.main.setSpecific(key: key, value: ())
         await systemUnderTest.enqueueAndWait {
-            XCTAssertTrue(Thread.isMainThread)
+            #expect(DispatchQueue.main.getSpecific(key: key) != nil)
         }
     }
 
-    func test_enqueueAndWait_allowsReentrancy() async {
+    @Test func test_enqueueAndWait_allowsReentrancy() async {
         await systemUnderTest.enqueueAndWait { [systemUnderTest, counter] in
             await systemUnderTest.enqueueAndWait { [counter] in
                 await counter.incrementAndExpectCount(equals: 1)
@@ -87,7 +82,7 @@ final class MainActorQueueTests: XCTestCase {
         }
     }
 
-    func test_enqueue_doesNotRetainTaskAfterExecution() async {
+    @Test func test_enqueue_doesNotRetainTaskAfterExecution() async {
         final class Reference: Sendable {}
         final class ReferenceHolder: @unchecked Sendable {
             init() {
@@ -107,7 +102,7 @@ final class MainActorQueueTests: XCTestCase {
         let systemUnderTest = ActorQueue<Semaphore>()
         systemUnderTest.adoptExecutionContext(of: syncSemaphore)
 
-        let expectation = self.expectation(description: #function)
+        let expectation = Expectation()
         systemUnderTest.enqueue { [reference = referenceHolder.reference] syncSemaphore in
             // Now that we've started the task and captured the reference, release the synchronous code.
             syncSemaphore.signal()
@@ -124,16 +119,16 @@ final class MainActorQueueTests: XCTestCase {
         // Wait for the asynchronous task to start.
         await syncSemaphore.wait()
         referenceHolder.clearReference()
-        XCTAssertNotNil(referenceHolder.weakReference)
+        #expect(referenceHolder.weakReference != nil)
         // Allow the enqueued task to complete.
         await asyncSemaphore.signal()
         // Make sure the task has completed.
-        await fulfillment(of: [expectation], timeout: 1.0)
+        await expectation.fulfillment(within: .seconds(1))
 
-        XCTAssertNil(referenceHolder.weakReference)
+        #expect(referenceHolder.weakReference == nil)
     }
 
-    func test_enqueueAndWait_sendsEventsInOrder() async {
+    @Test func test_enqueueAndWait_sendsEventsInOrder() async {
         for iteration in 1...1_000 {
             systemUnderTest.enqueue { [counter] in
                 await counter.incrementAndExpectCount(equals: iteration)
@@ -146,19 +141,19 @@ final class MainActorQueueTests: XCTestCase {
 
             await systemUnderTest.enqueueAndWait { [counter] in
                 let count = await counter.count
-                XCTAssertEqual(count, iteration)
+                #expect(count == iteration)
             }
         }
         await systemUnderTest.enqueueAndWait { /* Drain the queue */ }
     }
 
-    func test_enqueueAndWait_canReturn() async {
+    @Test func test_enqueueAndWait_canReturn() async {
         let expectedValue = UUID()
         let returnedValue = await systemUnderTest.enqueueAndWait { expectedValue }
-        XCTAssertEqual(expectedValue, returnedValue)
+        #expect(expectedValue == returnedValue)
     }
 
-    func test_enqueueAndWait_canThrow() async {
+    @Test func test_enqueueAndWait_canThrow() async {
         struct TestError: Error, Equatable {
             private let identifier = UUID()
         }
@@ -166,12 +161,12 @@ final class MainActorQueueTests: XCTestCase {
         do {
             try await systemUnderTest.enqueueAndWait { throw expectedError }
         } catch {
-            XCTAssertEqual(error as? TestError, expectedError)
+            #expect(error as? TestError == expectedError)
         }
     }
 
     // MARK: Private
 
-    private var systemUnderTest = MainActorQueue()
-    private var counter = Counter()
+    private let systemUnderTest = MainActorQueue()
+    private let counter = Counter()
 }

--- a/Tests/AsyncQueueTests/MainActorQueueTests.swift
+++ b/Tests/AsyncQueueTests/MainActorQueueTests.swift
@@ -82,6 +82,7 @@ struct MainActorQueueTests {
         }
     }
 
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @Test func test_enqueue_doesNotRetainTaskAfterExecution() async {
         final class Reference: Sendable {}
         final class ReferenceHolder: @unchecked Sendable {

--- a/Tests/AsyncQueueTests/MainActorQueueTests.swift
+++ b/Tests/AsyncQueueTests/MainActorQueueTests.swift
@@ -154,6 +154,16 @@ struct MainActorQueueTests {
         #expect(expectedValue == returnedValue)
     }
 
+    @Test func test_enqueueAndWait_throwing_canReturn() async throws {
+        let expectedValue = UUID()
+        @Sendable func throwingMethod() throws {}
+        let returnedValue = try await systemUnderTest.enqueueAndWait {
+            try throwingMethod()
+            return expectedValue
+        }
+        #expect(expectedValue == returnedValue)
+    }
+
     @Test func test_enqueueAndWait_canThrow() async {
         struct TestError: Error, Equatable {
             private let identifier = UUID()

--- a/Tests/AsyncQueueTests/Utilities/Counter.swift
+++ b/Tests/AsyncQueueTests/Utilities/Counter.swift
@@ -20,12 +20,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import XCTest
+import Testing
 
 actor Counter {
-    func incrementAndExpectCount(equals expectedCount: Int, file: StaticString = #filePath, line: UInt = #line) {
+    func incrementAndExpectCount(
+        equals expectedCount: Int,
+        filePath: String = #filePath,
+        fileID: String = #fileID,
+        line: Int = #line,
+        column: Int = #column
+    ) {
         increment()
-        XCTAssertEqual(expectedCount, count, file: file, line: line)
+        #expect(expectedCount == count, sourceLocation: .init(
+            fileID: filePath,
+            filePath: filePath,
+            line: line,
+            column: column
+        ))
     }
 
     func increment() {

--- a/Tests/AsyncQueueTests/Utilities/Expectation.swift
+++ b/Tests/AsyncQueueTests/Utilities/Expectation.swift
@@ -22,7 +22,6 @@
 
 import Testing
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public actor Expectation {
 
     // MARK: Initialization
@@ -46,6 +45,7 @@ public actor Expectation {
 
     // MARK: Public
 
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     public func fulfillment(
         within duration: Duration,
         filePath: String = #filePath,

--- a/Tests/AsyncQueueTests/Utilities/Expectation.swift
+++ b/Tests/AsyncQueueTests/Utilities/Expectation.swift
@@ -45,9 +45,8 @@ public actor Expectation {
 
     // MARK: Public
 
-    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     public func fulfillment(
-        within duration: Duration,
+        withinSeconds seconds: UInt64,
         filePath: String = #filePath,
         fileID: String = #fileID,
         line: Int = #line,
@@ -55,8 +54,8 @@ public actor Expectation {
     ) async {
         guard !isComplete else { return }
         let wait = Task {
-            try await Task.sleep(for: duration)
-            expect(isComplete, "Expectation not fulfilled within \(duration)", .init(
+            try await Task.sleep(nanoseconds: seconds * 1_000_000_000)
+            expect(isComplete, "Expectation not fulfilled within \(seconds) seconds", .init(
                 fileID: filePath,
                 filePath: filePath,
                 line: line,

--- a/Tests/AsyncQueueTests/Utilities/Expectation.swift
+++ b/Tests/AsyncQueueTests/Utilities/Expectation.swift
@@ -1,0 +1,121 @@
+// MIT License
+//
+// Copyright (c) 2024 Dan Federman
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Testing
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public actor Expectation {
+
+    // MARK: Initialization
+
+    public init(
+        expectedCount: UInt = 1
+    ) {
+        self.init(
+            expectedCount: expectedCount,
+            expect: { #expect($0, $1, sourceLocation: $2) }
+        )
+    }
+
+    init(
+        expectedCount: UInt,
+        expect: @escaping (Bool, Comment?, SourceLocation) -> Void
+    ) {
+        self.expectedCount = expectedCount
+        self.expect = expect
+    }
+
+    // MARK: Public
+
+    public func fulfillment(
+        within duration: Duration,
+        filePath: String = #filePath,
+        fileID: String = #fileID,
+        line: Int = #line,
+        column: Int = #column
+    ) async {
+        guard !isComplete else { return }
+        let wait = Task {
+            try await Task.sleep(for: duration)
+            expect(isComplete, "Expectation not fulfilled within \(duration)", .init(
+                fileID: filePath,
+                filePath: filePath,
+                line: line,
+                column: column
+            ))
+        }
+        waits.append(wait)
+        try? await wait.value
+    }
+
+    @discardableResult
+    nonisolated
+    public func fulfill(
+        filePath: String = #filePath,
+        fileID: String = #fileID,
+        line: Int = #line,
+        column: Int = #column
+    ) -> Task<Void, Never> {
+        Task {
+            await self._fulfill(
+                filePath: filePath,
+                fileID: fileID,
+                line: line,
+                column: column
+            )
+        }
+    }
+
+    // MARK: Private
+
+    private var waits = [Task<Void, Error>]()
+    private var fulfillCount: UInt = 0
+    private var isComplete: Bool {
+        expectedCount <= fulfillCount
+    }
+    private let expectedCount: UInt
+    private let expect: (Bool, Comment?, SourceLocation) -> Void
+
+    private func _fulfill(
+        filePath: String,
+        fileID: String,
+        line: Int,
+        column: Int
+    ) {
+        fulfillCount += 1
+        guard isComplete else { return }
+        expect(
+            expectedCount == fulfillCount,
+            "Expected \(expectedCount) calls to `fulfill()`. Received \(fulfillCount).",
+            .init(
+                fileID: filePath,
+                filePath: filePath,
+                line: line,
+                column: column
+            )
+        )
+        for wait in waits {
+            wait.cancel()
+        }
+        waits = []
+    }
+}

--- a/Tests/AsyncQueueTests/Utilities/Semaphore.swift
+++ b/Tests/AsyncQueueTests/Utilities/Semaphore.swift
@@ -21,11 +21,17 @@
 // SOFTWARE.
 
 /// A thread-safe semaphore implementation.
-actor Semaphore {
+public actor Semaphore {
+    // MARK: Initialization
+
+    public init() {}
+
+    // MARK: Public
+
     /// Decrement the counting semaphore. If the resulting value is less than zero, this function waits for a signal to occur before returning.
     /// - Returns: Whether the call triggered a suspension
     @discardableResult
-    func wait() async -> Bool {
+    public func wait() async -> Bool {
         count -= 1
         guard count < 0 else {
             // We don't need to wait because count is greater than or equal to zero.
@@ -39,7 +45,7 @@ actor Semaphore {
     }
 
     /// Increment the counting semaphore. If the previous value was less than zero, this function resumes a waiting thread before returning.
-    func signal() {
+    public func signal() {
         count += 1
         guard !isWaiting else {
             // Continue waiting.
@@ -53,9 +59,11 @@ actor Semaphore {
         continuations.removeAll()
     }
 
-    var isWaiting: Bool {
+    public var isWaiting: Bool {
         count < 0
     }
+
+    // MARK: Private
 
     private var continuations = [UnsafeContinuation<Void, Never>]()
     private var count = 0


### PR DESCRIPTION
Migrates from XCTest to [Swift Testing](https://developer.apple.com/documentation/testing). I ended up having to create an `Expectation` type to mimic what XCTest has, since [confirmations](https://developer.apple.com/documentation/testing/testing-asynchronous-code) require the `confirmation` to be confirmed before the confirmation closure exits, which doesn't work terribly well in a highly async environment.