### PR TITLE
Stop using CODECOV_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,6 @@ jobs:
       - name: Upload Coverage Reports
         if: success()
         uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
   readme-validation:
     name: Check Markdown links
     runs-on: ubuntu-latest


### PR DESCRIPTION
It's no longer required, and removing it enables forks to contribute and have CI succeed