### PR TITLE
Run CI on Swift 6.1 in Linux too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
       - name: Prepare Coverage Reports
         run: |
           llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/release/swift-async-queuePackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/release/codecov/default.profdata > coverage.lcov
+      - name: Install curl for Codecov
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends curl ca-certificates
       - name: Upload Coverage Reports
         if: success()
         uses: codecov/codecov-action@v5
@@ -121,6 +125,10 @@ jobs:
       - name: Prepare Coverage Reports
         run: |
           llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/release/swift-async-queuePackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/release/codecov/default.profdata > coverage.lcov
+      - name: Install curl for Codecov
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends curl ca-certificates
       - name: Upload Coverage Reports
         if: success()
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
It looks like Github Actions [is struggling to support multiple Xcode versions](https://github.com/actions/runner-images/issues/12541). To enable running CI against all of the Swift versions we support, I'm adding more Linux-based testing.