### PR TITLE
Use FoundationEssentials in CancellableQueue when available

### DIFF
--- a/Sources/AsyncQueue/CancellableQueue.swift
+++ b/Sources/AsyncQueue/CancellableQueue.swift
@@ -20,7 +20,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Foundation
+#if canImport(FoundationEssentials)
+	import FoundationEssentials
+#else
+	import Foundation
+#endif
+#if canImport(Dispatch)
+	import Dispatch
+#endif
 
 /// A queue wrapper that enables cancelling all currently executing and pending tasks.
 ///
@@ -398,7 +405,7 @@ private final class Lock<State>: @unchecked Sendable {
 
 	// MARK: Fileprivate
 
-	fileprivate func withLock<R>(_ body: @Sendable (inout State) throws -> R) rethrows -> R where R: Sendable {
+	fileprivate func withLock<R: Sendable>(_ body: @Sendable (inout State) throws -> R) rethrows -> R {
 		try lockQueue.sync {
 			try body(&unsafeValue)
 		}


### PR DESCRIPTION
## Motivation

`CancellableQueue.swift` is the only file in `AsyncQueue` that does a plain `import Foundation`. On Linux that single import pulls `libFoundation.so` → `libFoundationInternationalization.so` → `_FoundationICU` into the linked binary via the autolink directive — even though the file only uses `UUID` and `DispatchQueue`, and no ICU/internationalization functionality is ever called.

For size-constrained / embedded Linux targets this drags in the entire ICU data blob (tens of MB of flash) and the Foundation internationalization library for no functional benefit.

## Change

```swift
#if canImport(FoundationEssentials)
import FoundationEssentials   // UUID
import Dispatch               // DispatchQueue
#else
import Foundation
#endif
```

- `UUID` is provided by `FoundationEssentials`.
- `DispatchQueue` comes from `Dispatch` (already imported directly in `Utilities/Delivery.swift`, so this matches existing style in the package).
- Platforms without `FoundationEssentials` fall back to full `Foundation` exactly as before — no behavior change.

No public API change; `CancellableQueue` behaves identically. This just lets it link without full Foundation/ICU where `FoundationEssentials` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)