### PR TITLE
Download tvOS and watchOS simulator runtimes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,18 @@ jobs:
           sudo xcodebuild -runFirstLaunch
           sudo xcrun simctl list
           sudo xcodebuild -downloadPlatform iOS -buildVersion 22F77
+      - name: Download watchOS
+        if: matrix.platforms == 'iOS_18,watchOS_11'
+        run: |
+          sudo xcodebuild -runFirstLaunch
+          sudo xcrun simctl list
+          sudo xcodebuild -downloadPlatform watchOS -buildVersion 22T572
+      - name: Download tvOS
+        if: matrix.platforms == 'macOS_26,tvOS_18'
+        run: |
+          sudo xcodebuild -runFirstLaunch
+          sudo xcrun simctl list
+          sudo xcodebuild -downloadPlatform tvOS -buildVersion 22L572
       - name: Build and Test Framework
         run: Scripts/build.swift ${{ matrix.platforms }}
       - name: Prepare Coverage Reports


### PR DESCRIPTION
## What

Add explicit `xcodebuild -downloadPlatform` steps for **tvOS** and **watchOS** to the `Build Xcode 26` matrix jobs, mirroring the iOS step we already have (and the pattern used in [Valet](https://github.com/dfed/Valet)).

- tvOS 18.5 → `22L572`
- watchOS 11.5 → `22T572`

## Why

GitHub's hosted runners keep **no more than three simulator runtime sets per Xcode version** and evict the oldest as new releases ship (see [actions/runner-images#13570](https://github.com/actions/runner-images/issues/13570)). The tvOS 18.5 runtime got rotated out from under the `macOS_26,tvOS_18` job — which had **no download step at all** — so `xcodebuild` failed with:

```
xcodebuild: error: Unable to find a device matching the provided destination specifier:
        { platform:tvOS Simulator, OS:18.5, name:Apple TV }
```

That exits 70, which `Scripts/build.swift` rethrows as `TaskError.code(70)`, crashing the script (SIGTRAP → exit 133). It looked like the unrelated import-trimming commit (#76) broke CI, but that commit just happened to be the next push after the runtime was evicted — an import change can't cause "unable to find a simulator device."

`iOS_18,watchOS_11` only downloads iOS today and relies on watchOS 11.5 happening to be pre-installed; it will break the same way when that runtime is rotated out, so this hardens it now.

## Note

This does **not** address the intermittent visionOS test timeout (`*_executesAfterQueueIsDeallocated`, 30s expectation) seen under the `-test-iterations 100` stress harness — that's a separate slow-runner flake being investigated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)