### PR TITLE
Deflake queue-deallocation tests by awaiting the enqueued task

### DIFF
--- a/Tests/AsyncQueueTests/FIFOQueueTests.swift
+++ b/Tests/AsyncQueueTests/FIFOQueueTests.swift
@@ -265,17 +265,15 @@ struct FIFOQueueTests {
 	func task_executesAfterQueueIsDeallocated() async throws {
 		var systemUnderTest: FIFOQueue? = FIFOQueue()
 		let counter = Counter()
-		let expectation = Expectation()
 		let semaphore = Semaphore()
 		try Task(on: #require(systemUnderTest)) {
 			// Make the queue wait.
 			await semaphore.wait()
 			await counter.incrementAndExpectCount(equals: 1)
 		}
-		try Task(on: #require(systemUnderTest)) {
+		let lastTask = try Task(on: #require(systemUnderTest)) {
 			// This async task should not execute until the semaphore is released.
 			await counter.incrementAndExpectCount(equals: 2)
-			expectation.fulfill()
 		}
 		weak var queue = systemUnderTest
 		// Nil out our reference to the queue to show that the enqueued tasks will still complete
@@ -284,24 +282,23 @@ struct FIFOQueueTests {
 		// Signal the semaphore to unlock the remaining enqueued tasks.
 		await semaphore.signal()
 
-		await expectation.fulfillment(withinSeconds: 30)
+		// Await the last enqueued task to deterministically confirm the enqueued work ran after the queue was deallocated.
+		await lastTask.value
 	}
 
 	@Test
 	func taskIsolatedTo_executesAfterQueueIsDeallocated() async throws {
 		var systemUnderTest: FIFOQueue? = FIFOQueue()
 		let counter = Counter()
-		let expectation = Expectation()
 		let semaphore = Semaphore()
 		try Task(on: #require(systemUnderTest), isolatedTo: counter) { counter in
 			// Make the queue wait.
 			await semaphore.wait()
 			counter.incrementAndExpectCount(equals: 1)
 		}
-		try Task(on: #require(systemUnderTest), isolatedTo: counter) { counter in
+		let lastTask = try Task(on: #require(systemUnderTest), isolatedTo: counter) { counter in
 			// This async task should not execute until the semaphore is released.
 			counter.incrementAndExpectCount(equals: 2)
-			expectation.fulfill()
 		}
 		weak var queue = systemUnderTest
 		// Nil out our reference to the queue to show that the enqueued tasks will still complete
@@ -310,14 +307,14 @@ struct FIFOQueueTests {
 		// Signal the semaphore to unlock the remaining enqueued tasks.
 		await semaphore.signal()
 
-		await expectation.fulfillment(withinSeconds: 30)
+		// Await the last enqueued task to deterministically confirm the enqueued work ran after the queue was deallocated.
+		await lastTask.value
 	}
 
 	@Test
 	func throwingTask_executesAfterQueueIsDeallocated() async throws {
 		var systemUnderTest: FIFOQueue? = FIFOQueue()
 		let counter = Counter()
-		let expectation = Expectation()
 		let semaphore = Semaphore()
 		try Task(on: #require(systemUnderTest)) {
 			// Make the queue wait.
@@ -325,10 +322,9 @@ struct FIFOQueueTests {
 			await counter.incrementAndExpectCount(equals: 1)
 			try doWork()
 		}
-		try Task(on: #require(systemUnderTest)) {
+		let lastTask = try Task(on: #require(systemUnderTest)) {
 			// This async task should not execute until the semaphore is released.
 			await counter.incrementAndExpectCount(equals: 2)
-			expectation.fulfill()
 			try doWork()
 		}
 		weak var queue = systemUnderTest
@@ -338,14 +334,14 @@ struct FIFOQueueTests {
 		// Signal the semaphore to unlock the remaining enqueued tasks.
 		await semaphore.signal()
 
-		await expectation.fulfillment(withinSeconds: 30)
+		// Await the last enqueued task to deterministically confirm the enqueued work ran after the queue was deallocated.
+		try await lastTask.value
 	}
 
 	@Test
 	func throwingTaskIsolatedTo_executesAfterQueueIsDeallocated() async throws {
 		var systemUnderTest: FIFOQueue? = FIFOQueue()
 		let counter = Counter()
-		let expectation = Expectation()
 		let semaphore = Semaphore()
 		try Task(on: #require(systemUnderTest), isolatedTo: counter) { counter in
 			// Make the queue wait.
@@ -353,10 +349,9 @@ struct FIFOQueueTests {
 			counter.incrementAndExpectCount(equals: 1)
 			try doWork()
 		}
-		try Task(on: #require(systemUnderTest), isolatedTo: counter) { counter in
+		let lastTask = try Task(on: #require(systemUnderTest), isolatedTo: counter) { counter in
 			// This async task should not execute until the semaphore is released.
 			counter.incrementAndExpectCount(equals: 2)
-			expectation.fulfill()
 			try doWork()
 		}
 		weak var queue = systemUnderTest
@@ -366,7 +361,8 @@ struct FIFOQueueTests {
 		// Signal the semaphore to unlock the remaining enqueued tasks.
 		await semaphore.signal()
 
-		await expectation.fulfillment(withinSeconds: 30)
+		// Await the last enqueued task to deterministically confirm the enqueued work ran after the queue was deallocated.
+		try await lastTask.value
 	}
 
 	@Test


### PR DESCRIPTION
## What

Rewrite the four `*_executesAfterQueueIsDeallocated()` tests in `FIFOQueueTests` to `await` the final enqueued task's value instead of waiting on `Expectation.fulfillment(withinSeconds: 30)`.

## Why

These tests were the source of the intermittent `visionOS_2` CI failures (`Expectation not fulfilled within 30 seconds`, e.g. iteration 8/100). The expectation is a **wall-clock race**: it pits a `Task.sleep(30s)` against `fulfill()`, and `fulfill()` itself hops through an extra detached `Task`. Under the `-test-iterations 100 -run-tests-until-failure` stress harness on a slow, contended simulator, the cooperative pool can be starved long enough that the sleep wins before the queued work runs — a false failure. The identical code passes on macOS/iOS/Linux; it's purely runner-speed sensitivity.

## How it stays correct

`Task(on:)` captures only its `Delivery`/`Semaphore`, **never the `FIFOQueue`**, so holding the returned handle doesn't retain the queue — the `weak queue == nil` assertion still holds. Awaiting the last enqueued task is a strictly *stronger* check than the old expectation: it waits for the work to actually complete rather than for a side-channel flag, and the `Counter` assertions still verify execution order. Tests now complete in ~1ms regardless of runner speed.

The other `fulfillment(withinSeconds:)` call sites (e.g. `ExpectationTests`, which deliberately tests timeout behavior) are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)